### PR TITLE
Create index on creation_time only if it doesn't exist.

### DIFF
--- a/ldk-server/src/io/sqlite_store/mod.rs
+++ b/ldk-server/src/io/sqlite_store/mod.rs
@@ -96,7 +96,7 @@ impl SqliteStore {
 		})?;
 
 		let index_creation_time_sql = format!(
-			"CREATE INDEX idx_creation_time ON {} (creation_time);",
+			"CREATE INDEX IF NOT EXISTS idx_creation_time ON {} (creation_time);",
 			paginated_kv_table_name
 		);
 


### PR DESCRIPTION
Since index creation will fail if index already exists.