### PR TITLE
Make cli output json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -546,6 +546,9 @@ name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cbc"
@@ -1739,7 +1742,8 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "ldk-server-client",
- "prost",
+ "serde",
+ "serde_json",
  "tokio",
 ]
 
@@ -1756,8 +1760,10 @@ dependencies = [
 name = "ldk-server-protos"
 version = "0.1.0"
 dependencies = [
+ "bytes",
  "prost",
  "prost-build",
+ "serde",
 ]
 
 [[package]]

--- a/ldk-server-cli/Cargo.toml
+++ b/ldk-server-cli/Cargo.toml
@@ -4,7 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-ldk-server-client = { path = "../ldk-server-client" }
+ldk-server-client = { path = "../ldk-server-client", features = ["serde"] }
 clap = { version = "4.0.5", default-features = false, features = ["derive", "std", "error-context", "suggestions", "help"] }
 tokio = { version = "1.38.0", default-features = false, features = ["rt-multi-thread", "macros"] }
-prost = { version = "0.11.6", default-features = false}
+serde = "1.0"
+serde_json = "1.0"

--- a/ldk-server-cli/src/main.rs
+++ b/ldk-server-cli/src/main.rs
@@ -5,17 +5,20 @@ use ldk_server_client::error::LdkServerErrorCode::{
 	AuthError, InternalError, InternalServerError, InvalidRequestError, LightningError,
 };
 use ldk_server_client::ldk_server_protos::api::{
-	Bolt11ReceiveRequest, Bolt11SendRequest, Bolt12ReceiveRequest, Bolt12SendRequest,
-	CloseChannelRequest, ForceCloseChannelRequest, GetBalancesRequest, GetNodeInfoRequest,
-	ListChannelsRequest, ListPaymentsRequest, OnchainReceiveRequest, OnchainSendRequest,
-	OpenChannelRequest, SpliceInRequest, SpliceOutRequest, UpdateChannelConfigRequest,
+	Bolt11ReceiveRequest, Bolt11ReceiveResponse, Bolt11SendRequest, Bolt11SendResponse,
+	Bolt12ReceiveRequest, Bolt12ReceiveResponse, Bolt12SendRequest, Bolt12SendResponse,
+	CloseChannelRequest, CloseChannelResponse, ForceCloseChannelRequest, ForceCloseChannelResponse,
+	GetBalancesRequest, GetBalancesResponse, GetNodeInfoRequest, GetNodeInfoResponse,
+	ListChannelsRequest, ListChannelsResponse, ListPaymentsRequest, ListPaymentsResponse,
+	OnchainReceiveRequest, OnchainReceiveResponse, OnchainSendRequest, OnchainSendResponse,
+	OpenChannelRequest, OpenChannelResponse, SpliceInRequest, SpliceInResponse, SpliceOutRequest,
+	SpliceOutResponse, UpdateChannelConfigRequest, UpdateChannelConfigResponse,
 };
-use ldk_server_client::ldk_server_protos::types::RouteParametersConfig;
 use ldk_server_client::ldk_server_protos::types::{
-	bolt11_invoice_description, channel_config, Bolt11InvoiceDescription, ChannelConfig, PageToken,
-	Payment,
+	bolt11_invoice_description, Bolt11InvoiceDescription, ChannelConfig, PageToken, Payment,
+	RouteParametersConfig,
 };
-use std::fmt::Debug;
+use serde::Serialize;
 
 // Having these default values as constants in the Proto file and
 // importing/reusing them here might be better, but Proto3 removed
@@ -199,16 +202,22 @@ async fn main() {
 
 	match cli.command {
 		Commands::GetNodeInfo => {
-			handle_response_result(client.get_node_info(GetNodeInfoRequest {}).await);
+			handle_response_result::<_, GetNodeInfoResponse>(
+				client.get_node_info(GetNodeInfoRequest {}).await,
+			);
 		},
 		Commands::GetBalances => {
-			handle_response_result(client.get_balances(GetBalancesRequest {}).await);
+			handle_response_result::<_, GetBalancesResponse>(
+				client.get_balances(GetBalancesRequest {}).await,
+			);
 		},
 		Commands::OnchainReceive => {
-			handle_response_result(client.onchain_receive(OnchainReceiveRequest {}).await);
+			handle_response_result::<_, OnchainReceiveResponse>(
+				client.onchain_receive(OnchainReceiveRequest {}).await,
+			);
 		},
 		Commands::OnchainSend { address, amount_sats, send_all, fee_rate_sat_per_vb } => {
-			handle_response_result(
+			handle_response_result::<_, OnchainSendResponse>(
 				client
 					.onchain_send(OnchainSendRequest {
 						address,
@@ -239,7 +248,9 @@ async fn main() {
 			let request =
 				Bolt11ReceiveRequest { description: invoice_description, expiry_secs, amount_msat };
 
-			handle_response_result(client.bolt11_receive(request).await);
+			handle_response_result::<_, Bolt11ReceiveResponse>(
+				client.bolt11_receive(request).await,
+			);
 		},
 		Commands::Bolt11Send {
 			invoice,
@@ -257,7 +268,7 @@ async fn main() {
 				max_channel_saturation_power_of_half: max_channel_saturation_power_of_half
 					.unwrap_or(DEFAULT_MAX_CHANNEL_SATURATION_POWER_OF_HALF),
 			};
-			handle_response_result(
+			handle_response_result::<_, Bolt11SendResponse>(
 				client
 					.bolt11_send(Bolt11SendRequest {
 						invoice,
@@ -268,7 +279,7 @@ async fn main() {
 			);
 		},
 		Commands::Bolt12Receive { description, amount_msat, expiry_secs, quantity } => {
-			handle_response_result(
+			handle_response_result::<_, Bolt12ReceiveResponse>(
 				client
 					.bolt12_receive(Bolt12ReceiveRequest {
 						description,
@@ -298,7 +309,7 @@ async fn main() {
 					.unwrap_or(DEFAULT_MAX_CHANNEL_SATURATION_POWER_OF_HALF),
 			};
 
-			handle_response_result(
+			handle_response_result::<_, Bolt12SendResponse>(
 				client
 					.bolt12_send(Bolt12SendRequest {
 						offer,
@@ -311,7 +322,7 @@ async fn main() {
 			);
 		},
 		Commands::CloseChannel { user_channel_id, counterparty_node_id } => {
-			handle_response_result(
+			handle_response_result::<_, CloseChannelResponse>(
 				client
 					.close_channel(CloseChannelRequest { user_channel_id, counterparty_node_id })
 					.await,
@@ -322,7 +333,7 @@ async fn main() {
 			counterparty_node_id,
 			force_close_reason,
 		} => {
-			handle_response_result(
+			handle_response_result::<_, ForceCloseChannelResponse>(
 				client
 					.force_close_channel(ForceCloseChannelRequest {
 						user_channel_id,
@@ -348,7 +359,7 @@ async fn main() {
 				cltv_expiry_delta,
 			);
 
-			handle_response_result(
+			handle_response_result::<_, OpenChannelResponse>(
 				client
 					.open_channel(OpenChannelRequest {
 						node_pubkey,
@@ -362,7 +373,7 @@ async fn main() {
 			);
 		},
 		Commands::SpliceIn { user_channel_id, counterparty_node_id, splice_amount_sats } => {
-			handle_response_result(
+			handle_response_result::<_, SpliceInResponse>(
 				client
 					.splice_in(SpliceInRequest {
 						user_channel_id,
@@ -378,7 +389,7 @@ async fn main() {
 			address,
 			splice_amount_sats,
 		} => {
-			handle_response_result(
+			handle_response_result::<_, SpliceOutResponse>(
 				client
 					.splice_out(SpliceOutRequest {
 						user_channel_id,
@@ -390,10 +401,17 @@ async fn main() {
 			);
 		},
 		Commands::ListChannels => {
-			handle_response_result(client.list_channels(ListChannelsRequest {}).await);
+			handle_response_result::<_, ListChannelsResponse>(
+				client.list_channels(ListChannelsRequest {}).await,
+			);
 		},
 		Commands::ListPayments { number_of_payments } => {
-			handle_response_result(list_n_payments(client, number_of_payments).await);
+			handle_response_result::<_, ListPaymentsResponse>(
+				list_n_payments(client, number_of_payments)
+					.await
+					// todo: handle pagination properly
+					.map(|payments| ListPaymentsResponse { payments, next_page_token: None }),
+			);
 		},
 		Commands::UpdateChannelConfig {
 			user_channel_id,
@@ -411,7 +429,7 @@ async fn main() {
 				max_dust_htlc_exposure: None,
 			};
 
-			handle_response_result(
+			handle_response_result::<_, UpdateChannelConfigResponse>(
 				client
 					.update_channel_config(UpdateChannelConfigRequest {
 						user_channel_id,
@@ -466,10 +484,21 @@ async fn list_n_payments(
 	Ok(payments)
 }
 
-fn handle_response_result<Rs: Debug>(response: Result<Rs, LdkServerError>) {
+fn handle_response_result<Rs, Js>(response: Result<Rs, LdkServerError>)
+where
+	Rs: Into<Js>,
+	Js: Serialize + std::fmt::Debug,
+{
 	match response {
 		Ok(response) => {
-			println!("Success: {:?}", response);
+			let json_response: Js = response.into();
+			match serde_json::to_string_pretty(&json_response) {
+				Ok(json) => println!("{json}"),
+				Err(e) => {
+					eprintln!("Error serializing response ({json_response:?}) to JSON: {e}");
+					std::process::exit(1);
+				},
+			}
 		},
 		Err(e) => {
 			handle_error(e);

--- a/ldk-server-client/Cargo.toml
+++ b/ldk-server-client/Cargo.toml
@@ -3,6 +3,10 @@ name = "ldk-server-client"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+default = []
+serde = ["ldk-server-protos/serde"]
+
 [dependencies]
 ldk-server-protos = { path = "../ldk-server-protos" }
 reqwest = { version = "0.11.13", default-features = false, features = ["rustls-tls"] }

--- a/ldk-server-protos/Cargo.toml
+++ b/ldk-server-protos/Cargo.toml
@@ -5,8 +5,14 @@ edition = "2021"
 
 build = "build.rs"
 
+[features]
+default = []
+serde = ["dep:serde", "dep:bytes"]
+
 [dependencies]
 prost = { version = "0.11.6", default-features = false, features = ["std", "prost-derive"] }
+serde = { version = "1.0", features = ["derive"], optional = true }
+bytes = { version = "1", features = ["serde"], optional = true }
 
 [target.'cfg(genproto)'.build-dependencies]
-prost-build = { version = "0.11.6" , default-features = false}
+prost-build = { version = "0.11.6", default-features = false }

--- a/ldk-server-protos/build.rs
+++ b/ldk-server-protos/build.rs
@@ -14,6 +14,11 @@ fn main() {
 fn generate_protos() {
 	prost_build::Config::new()
 		.bytes(&["."])
+		.type_attribute(
+			".",
+			"#[cfg_attr(feature = \"serde\", derive(serde::Serialize, serde::Deserialize))]",
+		)
+		.type_attribute(".", "#[cfg_attr(feature = \"serde\", serde(rename_all = \"snake_case\"))]")
 		.compile_protos(
 			&[
 				"src/proto/api.proto",

--- a/ldk-server-protos/src/api.rs
+++ b/ldk-server-protos/src/api.rs
@@ -2,11 +2,15 @@
 /// See more:
 /// - <https://docs.rs/ldk-node/latest/ldk_node/struct.Node.html#method.node_id>
 /// - <https://docs.rs/ldk-node/latest/ldk_node/struct.Node.html#method.status>
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetNodeInfoRequest {}
 /// The response `content` for the `GetNodeInfo` API, when HttpStatusCode is OK (200).
 /// When HttpStatusCode is not OK (non-200), the response `content` contains a serialized `ErrorResponse`.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetNodeInfoResponse {
@@ -49,11 +53,15 @@ pub struct GetNodeInfoResponse {
 }
 /// Retrieve a new on-chain funding address.
 /// See more: <https://docs.rs/ldk-node/latest/ldk_node/payment/struct.OnchainPayment.html#method.new_address>
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct OnchainReceiveRequest {}
 /// The response `content` for the `OnchainReceive` API, when HttpStatusCode is OK (200).
 /// When HttpStatusCode is not OK (non-200), the response `content` contains a serialized `ErrorResponse`..
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct OnchainReceiveResponse {
@@ -62,6 +70,8 @@ pub struct OnchainReceiveResponse {
 	pub address: ::prost::alloc::string::String,
 }
 /// Send an on-chain payment to the given address.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct OnchainSendRequest {
@@ -90,6 +100,8 @@ pub struct OnchainSendRequest {
 }
 /// The response `content` for the `OnchainSend` API, when HttpStatusCode is OK (200).
 /// When HttpStatusCode is not OK (non-200), the response `content` contains a serialized `ErrorResponse`.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct OnchainSendResponse {
@@ -103,6 +115,8 @@ pub struct OnchainSendResponse {
 /// See more:
 /// - <https://docs.rs/ldk-node/latest/ldk_node/payment/struct.Bolt11Payment.html#method.receive>
 /// - <https://docs.rs/ldk-node/latest/ldk_node/payment/struct.Bolt11Payment.html#method.receive_variable_amount>
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Bolt11ReceiveRequest {
@@ -119,6 +133,8 @@ pub struct Bolt11ReceiveRequest {
 }
 /// The response `content` for the `Bolt11Receive` API, when HttpStatusCode is OK (200).
 /// When HttpStatusCode is not OK (non-200), the response `content` contains a serialized `ErrorResponse`.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Bolt11ReceiveResponse {
@@ -130,6 +146,8 @@ pub struct Bolt11ReceiveResponse {
 }
 /// Send a payment for a BOLT11 invoice.
 /// See more: <https://docs.rs/ldk-node/latest/ldk_node/payment/struct.Bolt11Payment.html#method.send>
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Bolt11SendRequest {
@@ -147,6 +165,8 @@ pub struct Bolt11SendRequest {
 }
 /// The response `content` for the `Bolt11Send` API, when HttpStatusCode is OK (200).
 /// When HttpStatusCode is not OK (non-200), the response `content` contains a serialized `ErrorResponse`.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Bolt11SendResponse {
@@ -159,6 +179,8 @@ pub struct Bolt11SendResponse {
 /// See more:
 /// - <https://docs.rs/ldk-node/latest/ldk_node/payment/struct.Bolt12Payment.html#method.receive>
 /// - <https://docs.rs/ldk-node/latest/ldk_node/payment/struct.Bolt12Payment.html#method.receive_variable_amount>
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Bolt12ReceiveRequest {
@@ -178,6 +200,8 @@ pub struct Bolt12ReceiveRequest {
 }
 /// The response `content` for the `Bolt12Receive` API, when HttpStatusCode is OK (200).
 /// When HttpStatusCode is not OK (non-200), the response `content` contains a serialized `ErrorResponse`.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Bolt12ReceiveResponse {
@@ -191,6 +215,8 @@ pub struct Bolt12ReceiveResponse {
 /// See more:
 /// - <https://docs.rs/ldk-node/latest/ldk_node/payment/struct.Bolt12Payment.html#method.send>
 /// - <https://docs.rs/ldk-node/latest/ldk_node/payment/struct.Bolt12Payment.html#method.send_using_amount>
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Bolt12SendRequest {
@@ -214,6 +240,8 @@ pub struct Bolt12SendRequest {
 }
 /// The response `content` for the `Bolt12Send` API, when HttpStatusCode is OK (200).
 /// When HttpStatusCode is not OK (non-200), the response `content` contains a serialized `ErrorResponse`.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Bolt12SendResponse {
@@ -223,6 +251,8 @@ pub struct Bolt12SendResponse {
 }
 /// Creates a new outbound channel to the given remote node.
 /// See more: <https://docs.rs/ldk-node/latest/ldk_node/struct.Node.html#method.connect_open_channel>
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct OpenChannelRequest {
@@ -248,6 +278,8 @@ pub struct OpenChannelRequest {
 }
 /// The response `content` for the `OpenChannel` API, when HttpStatusCode is OK (200).
 /// When HttpStatusCode is not OK (non-200), the response `content` contains a serialized `ErrorResponse`.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct OpenChannelResponse {
@@ -256,7 +288,9 @@ pub struct OpenChannelResponse {
 	pub user_channel_id: ::prost::alloc::string::String,
 }
 /// Increases the channel balance by the given amount.
-/// See more: <https://docs.rs/ldk-node/latest/ldk_node/struct.Node.html#method.splice_in_channel>
+/// See more: <https://docs.rs/ldk-node/latest/ldk_node/struct.Node.html#method.splice_in>
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SpliceInRequest {
@@ -272,11 +306,15 @@ pub struct SpliceInRequest {
 }
 /// The response `content` for the `SpliceIn` API, when HttpStatusCode is OK (200).
 /// When HttpStatusCode is not OK (non-200), the response `content` contains a serialized `ErrorResponse`.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SpliceInResponse {}
 /// Decreases the channel balance by the given amount.
-/// See more: <https://docs.rs/ldk-node/latest/ldk_node/struct.Node.html#method.splice_out_channel>
+/// See more: <https://docs.rs/ldk-node/latest/ldk_node/struct.Node.html#method.splice_out>
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SpliceOutRequest {
@@ -297,6 +335,8 @@ pub struct SpliceOutRequest {
 }
 /// The response `content` for the `SpliceOut` API, when HttpStatusCode is OK (200).
 /// When HttpStatusCode is not OK (non-200), the response `content` contains a serialized `ErrorResponse`.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct SpliceOutResponse {
@@ -306,6 +346,8 @@ pub struct SpliceOutResponse {
 }
 /// Update the config for a previously opened channel.
 /// See more: <https://docs.rs/ldk-node/latest/ldk_node/struct.Node.html#method.update_channel_config>
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateChannelConfigRequest {
@@ -321,11 +363,15 @@ pub struct UpdateChannelConfigRequest {
 }
 /// The response `content` for the `UpdateChannelConfig` API, when HttpStatusCode is OK (200).
 /// When HttpStatusCode is not OK (non-200), the response `content` contains a serialized `ErrorResponse`.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct UpdateChannelConfigResponse {}
 /// Closes the channel specified by given request.
 /// See more: <https://docs.rs/ldk-node/latest/ldk_node/struct.Node.html#method.close_channel>
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CloseChannelRequest {
@@ -338,11 +384,15 @@ pub struct CloseChannelRequest {
 }
 /// The response `content` for the `CloseChannel` API, when HttpStatusCode is OK (200).
 /// When HttpStatusCode is not OK (non-200), the response `content` contains a serialized `ErrorResponse`.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CloseChannelResponse {}
 /// Force closes the channel specified by given request.
 /// See more: <https://docs.rs/ldk-node/latest/ldk_node/struct.Node.html#method.force_close_channel>
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ForceCloseChannelRequest {
@@ -358,16 +408,22 @@ pub struct ForceCloseChannelRequest {
 }
 /// The response `content` for the `ForceCloseChannel` API, when HttpStatusCode is OK (200).
 /// When HttpStatusCode is not OK (non-200), the response `content` contains a serialized `ErrorResponse`.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ForceCloseChannelResponse {}
 /// Returns a list of known channels.
 /// See more: <https://docs.rs/ldk-node/latest/ldk_node/struct.Node.html#method.list_channels>
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListChannelsRequest {}
 /// The response `content` for the `ListChannels` API, when HttpStatusCode is OK (200).
 /// When HttpStatusCode is not OK (non-200), the response `content` contains a serialized `ErrorResponse`.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListChannelsResponse {
@@ -377,6 +433,8 @@ pub struct ListChannelsResponse {
 }
 /// Returns payment details for a given payment_id.
 /// See more: <https://docs.rs/ldk-node/latest/ldk_node/struct.Node.html#method.payment>
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetPaymentDetailsRequest {
@@ -386,6 +444,8 @@ pub struct GetPaymentDetailsRequest {
 }
 /// The response `content` for the `GetPaymentDetails` API, when HttpStatusCode is OK (200).
 /// When HttpStatusCode is not OK (non-200), the response `content` contains a serialized `ErrorResponse`.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetPaymentDetailsResponse {
@@ -396,6 +456,8 @@ pub struct GetPaymentDetailsResponse {
 }
 /// Retrieves list of all payments.
 /// See more: <https://docs.rs/ldk-node/latest/ldk_node/struct.Node.html#method.list_payments>
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListPaymentsRequest {
@@ -410,6 +472,8 @@ pub struct ListPaymentsRequest {
 }
 /// The response `content` for the `ListPayments` API, when HttpStatusCode is OK (200).
 /// When HttpStatusCode is not OK (non-200), the response `content` contains a serialized `ErrorResponse`.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListPaymentsResponse {
@@ -434,6 +498,8 @@ pub struct ListPaymentsResponse {
 }
 /// Retrieves list of all forwarded payments.
 /// See more: <https://docs.rs/ldk-node/latest/ldk_node/enum.Event.html#variant.PaymentForwarded>
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListForwardedPaymentsRequest {
@@ -448,6 +514,8 @@ pub struct ListForwardedPaymentsRequest {
 }
 /// The response `content` for the `ListForwardedPayments` API, when HttpStatusCode is OK (200).
 /// When HttpStatusCode is not OK (non-200), the response `content` contains a serialized `ErrorResponse`.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ListForwardedPaymentsResponse {
@@ -472,11 +540,15 @@ pub struct ListForwardedPaymentsResponse {
 }
 /// Retrieves an overview of all known balances.
 /// See more: <https://docs.rs/ldk-node/latest/ldk_node/struct.Node.html#method.list_balances>
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetBalancesRequest {}
 /// The response `content` for the `GetBalances` API, when HttpStatusCode is OK (200).
 /// When HttpStatusCode is not OK (non-200), the response `content` contains a serialized `ErrorResponse`.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct GetBalancesResponse {

--- a/ldk-server-protos/src/error.rs
+++ b/ldk-server-protos/src/error.rs
@@ -1,5 +1,7 @@
 /// When HttpStatusCode is not ok (200), the response `content` contains a serialized `ErrorResponse`
 /// with the relevant ErrorCode and `message`
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ErrorResponse {
@@ -17,6 +19,8 @@ pub struct ErrorResponse {
 	#[prost(enumeration = "ErrorCode", tag = "2")]
 	pub error_code: i32,
 }
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum ErrorCode {

--- a/ldk-server-protos/src/events.rs
+++ b/ldk-server-protos/src/events.rs
@@ -1,4 +1,6 @@
 /// EventEnvelope wraps different event types in a single message to be used by EventPublisher.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct EventEnvelope {
@@ -7,6 +9,8 @@ pub struct EventEnvelope {
 }
 /// Nested message and enum types in `EventEnvelope`.
 pub mod event_envelope {
+	#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+	#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 	#[allow(clippy::derive_partial_eq_without_eq)]
 	#[derive(Clone, PartialEq, ::prost::Oneof)]
 	pub enum Event {
@@ -21,6 +25,8 @@ pub mod event_envelope {
 	}
 }
 /// PaymentReceived indicates a payment has been received.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PaymentReceived {
@@ -29,6 +35,8 @@ pub struct PaymentReceived {
 	pub payment: ::core::option::Option<super::types::Payment>,
 }
 /// PaymentSuccessful indicates a sent payment was successful.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PaymentSuccessful {
@@ -37,6 +45,8 @@ pub struct PaymentSuccessful {
 	pub payment: ::core::option::Option<super::types::Payment>,
 }
 /// PaymentFailed indicates a sent payment has failed.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PaymentFailed {
@@ -45,6 +55,8 @@ pub struct PaymentFailed {
 	pub payment: ::core::option::Option<super::types::Payment>,
 }
 /// PaymentForwarded indicates a payment was forwarded through the node.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PaymentForwarded {

--- a/ldk-server-protos/src/types.rs
+++ b/ldk-server-protos/src/types.rs
@@ -1,5 +1,7 @@
 /// Represents a payment.
 /// See more: <https://docs.rs/ldk-node/latest/ldk_node/payment/struct.PaymentDetails.html>
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Payment {
@@ -28,6 +30,8 @@ pub struct Payment {
 	#[prost(uint64, tag = "6")]
 	pub latest_update_timestamp: u64,
 }
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PaymentKind {
@@ -36,6 +40,8 @@ pub struct PaymentKind {
 }
 /// Nested message and enum types in `PaymentKind`.
 pub mod payment_kind {
+	#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+	#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 	#[allow(clippy::derive_partial_eq_without_eq)]
 	#[derive(Clone, PartialEq, ::prost::Oneof)]
 	pub enum Kind {
@@ -54,6 +60,8 @@ pub mod payment_kind {
 	}
 }
 /// Represents an on-chain payment.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Onchain {
@@ -64,6 +72,8 @@ pub struct Onchain {
 	#[prost(message, optional, tag = "2")]
 	pub status: ::core::option::Option<ConfirmationStatus>,
 }
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ConfirmationStatus {
@@ -72,6 +82,8 @@ pub struct ConfirmationStatus {
 }
 /// Nested message and enum types in `ConfirmationStatus`.
 pub mod confirmation_status {
+	#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+	#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 	#[allow(clippy::derive_partial_eq_without_eq)]
 	#[derive(Clone, PartialEq, ::prost::Oneof)]
 	pub enum Status {
@@ -82,6 +94,8 @@ pub mod confirmation_status {
 	}
 }
 /// The on-chain transaction is confirmed in the best chain.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Confirmed {
@@ -96,10 +110,14 @@ pub struct Confirmed {
 	pub timestamp: u64,
 }
 /// The on-chain transaction is unconfirmed.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Unconfirmed {}
 /// Represents a BOLT 11 payment.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Bolt11 {
@@ -114,6 +132,8 @@ pub struct Bolt11 {
 	pub secret: ::core::option::Option<::prost::bytes::Bytes>,
 }
 /// Represents a BOLT 11 payment intended to open an LSPS 2 just-in-time channel.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Bolt11Jit {
@@ -142,6 +162,8 @@ pub struct Bolt11Jit {
 	pub counterparty_skimmed_fee_msat: ::core::option::Option<u64>,
 }
 /// Represents a BOLT 12 ‘offer’ payment, i.e., a payment for an Offer.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Bolt12Offer {
@@ -169,6 +191,8 @@ pub struct Bolt12Offer {
 	pub quantity: ::core::option::Option<u64>,
 }
 /// Represents a BOLT 12 ‘refund’ payment, i.e., a payment for a Refund.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Bolt12Refund {
@@ -193,6 +217,8 @@ pub struct Bolt12Refund {
 	pub quantity: ::core::option::Option<u64>,
 }
 /// Represents a spontaneous (“keysend”) payment.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Spontaneous {
@@ -207,6 +233,8 @@ pub struct Spontaneous {
 /// See \[`LdkChannelConfig::accept_underpaying_htlcs`\] for more information.
 ///
 /// \[`LdkChannelConfig::accept_underpaying_htlcs`\]: lightning::util::config::ChannelConfig::accept_underpaying_htlcs
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LspFeeLimits {
@@ -221,6 +249,8 @@ pub struct LspFeeLimits {
 }
 /// A forwarded payment through our node.
 /// See more: <https://docs.rs/ldk-node/latest/ldk_node/enum.Event.html#variant.PaymentForwarded>
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ForwardedPayment {
@@ -271,6 +301,8 @@ pub struct ForwardedPayment {
 	#[prost(uint64, optional, tag = "8")]
 	pub outbound_amount_forwarded_msat: ::core::option::Option<u64>,
 }
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Channel {
@@ -403,6 +435,8 @@ pub struct Channel {
 }
 /// ChannelConfig represents the configuration settings for a channel in a Lightning Network node.
 /// See more: <https://docs.rs/lightning/latest/lightning/util/config/struct.ChannelConfig.html>
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ChannelConfig {
@@ -446,6 +480,8 @@ pub mod channel_config {
 	/// and fees on commitment transaction(s) broadcasted by our counterparty in excess of
 	/// our own fee estimate.
 	/// See more: <https://docs.rs/lightning/latest/lightning/util/config/struct.ChannelConfig.html#structfield.max_dust_htlc_exposure>
+	#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+	#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 	#[allow(clippy::derive_partial_eq_without_eq)]
 	#[derive(Clone, PartialEq, ::prost::Oneof)]
 	pub enum MaxDustHtlcExposure {
@@ -460,6 +496,8 @@ pub mod channel_config {
 	}
 }
 /// Represent a transaction outpoint.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct OutPoint {
@@ -470,6 +508,8 @@ pub struct OutPoint {
 	#[prost(uint32, tag = "2")]
 	pub vout: u32,
 }
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BestBlock {
@@ -481,6 +521,8 @@ pub struct BestBlock {
 	pub height: u32,
 }
 /// Details about the status of a known Lightning balance.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct LightningBalance {
@@ -489,6 +531,8 @@ pub struct LightningBalance {
 }
 /// Nested message and enum types in `LightningBalance`.
 pub mod lightning_balance {
+	#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+	#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 	#[allow(clippy::derive_partial_eq_without_eq)]
 	#[derive(Clone, PartialEq, ::prost::Oneof)]
 	pub enum BalanceType {
@@ -509,6 +553,8 @@ pub mod lightning_balance {
 /// The channel is not yet closed (or the commitment or closing transaction has not yet appeared in a block).
 /// The given balance is claimable (less on-chain fees) if the channel is force-closed now.
 /// See more: <https://docs.rs/ldk-node/latest/ldk_node/enum.LightningBalance.html#variant.ClaimableOnChannelClose>
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ClaimableOnChannelClose {
@@ -564,6 +610,8 @@ pub struct ClaimableOnChannelClose {
 }
 /// The channel has been closed, and the given balance is ours but awaiting confirmations until we consider it spendable.
 /// See more: <https://docs.rs/ldk-node/latest/ldk_node/enum.LightningBalance.html#variant.ClaimableAwaitingConfirmations>
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ClaimableAwaitingConfirmations {
@@ -588,6 +636,8 @@ pub struct ClaimableAwaitingConfirmations {
 /// Once the spending transaction confirms, before it has reached enough confirmations to be considered safe from chain
 /// reorganizations, the balance will instead be provided via `LightningBalance::ClaimableAwaitingConfirmations`.
 /// See more: <https://docs.rs/ldk-node/latest/ldk_node/enum.LightningBalance.html#variant.ContentiousClaimable>
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ContentiousClaimable {
@@ -614,6 +664,8 @@ pub struct ContentiousClaimable {
 /// HTLCs which we sent to our counterparty which are claimable after a timeout (less on-chain fees) if the counterparty
 /// does not know the preimage for the HTLCs. These are somewhat likely to be claimed by our counterparty before we do.
 /// See more: <https://docs.rs/ldk-node/latest/ldk_node/enum.LightningBalance.html#variant.MaybeTimeoutClaimableHTLC>
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MaybeTimeoutClaimableHtlc {
@@ -641,6 +693,8 @@ pub struct MaybeTimeoutClaimableHtlc {
 /// This will only be claimable if we receive the preimage from the node to which we forwarded this HTLC before the
 /// timeout.
 /// See more: <https://docs.rs/ldk-node/latest/ldk_node/enum.LightningBalance.html#variant.MaybePreimageClaimableHTLC>
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct MaybePreimageClaimableHtlc {
@@ -667,6 +721,8 @@ pub struct MaybePreimageClaimableHtlc {
 /// Thus, we’re able to claim all outputs in the commitment transaction, one of which has the following amount.
 ///
 /// See more: <https://docs.rs/ldk-node/latest/ldk_node/enum.LightningBalance.html#variant.CounterpartyRevokedOutputClaimable>
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct CounterpartyRevokedOutputClaimable {
@@ -681,6 +737,8 @@ pub struct CounterpartyRevokedOutputClaimable {
 	pub amount_satoshis: u64,
 }
 /// Details about the status of a known balance currently being swept to our on-chain wallet.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PendingSweepBalance {
@@ -689,6 +747,8 @@ pub struct PendingSweepBalance {
 }
 /// Nested message and enum types in `PendingSweepBalance`.
 pub mod pending_sweep_balance {
+	#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+	#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 	#[allow(clippy::derive_partial_eq_without_eq)]
 	#[derive(Clone, PartialEq, ::prost::Oneof)]
 	pub enum BalanceType {
@@ -702,6 +762,8 @@ pub mod pending_sweep_balance {
 }
 /// The spendable output is about to be swept, but a spending transaction has yet to be generated and broadcast.
 /// See more: <https://docs.rs/ldk-node/latest/ldk_node/enum.PendingSweepBalance.html#variant.PendingBroadcast>
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PendingBroadcast {
@@ -714,6 +776,8 @@ pub struct PendingBroadcast {
 }
 /// A spending transaction has been generated and broadcast and is awaiting confirmation on-chain.
 /// See more: <https://docs.rs/ldk-node/latest/ldk_node/enum.PendingSweepBalance.html#variant.BroadcastAwaitingConfirmation>
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BroadcastAwaitingConfirmation {
@@ -734,6 +798,8 @@ pub struct BroadcastAwaitingConfirmation {
 ///
 /// It will be considered irrevocably confirmed after reaching `ANTI_REORG_DELAY`.
 /// See more: <https://docs.rs/ldk-node/latest/ldk_node/enum.PendingSweepBalance.html#variant.AwaitingThresholdConfirmations>
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AwaitingThresholdConfirmations {
@@ -754,6 +820,8 @@ pub struct AwaitingThresholdConfirmations {
 	pub amount_satoshis: u64,
 }
 /// Token used to determine start of next page in paginated APIs.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PageToken {
@@ -762,6 +830,8 @@ pub struct PageToken {
 	#[prost(int64, tag = "2")]
 	pub index: i64,
 }
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct Bolt11InvoiceDescription {
@@ -770,6 +840,8 @@ pub struct Bolt11InvoiceDescription {
 }
 /// Nested message and enum types in `Bolt11InvoiceDescription`.
 pub mod bolt11_invoice_description {
+	#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+	#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 	#[allow(clippy::derive_partial_eq_without_eq)]
 	#[derive(Clone, PartialEq, ::prost::Oneof)]
 	pub enum Kind {
@@ -781,6 +853,8 @@ pub mod bolt11_invoice_description {
 }
 /// Configuration options for payment routing and pathfinding.
 /// See <https://docs.rs/lightning/0.2.0/lightning/routing/router/struct.RouteParametersConfig.html> for more details on each field.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RouteParametersConfig {
@@ -803,6 +877,8 @@ pub struct RouteParametersConfig {
 	pub max_channel_saturation_power_of_half: u32,
 }
 /// Represents the direction of a payment.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum PaymentDirection {
@@ -832,6 +908,8 @@ impl PaymentDirection {
 	}
 }
 /// Represents the current status of a payment.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
 #[repr(i32)]
 pub enum PaymentStatus {


### PR DESCRIPTION
Previously we would output the debug format of each of our return times which worked, but was not very usable. You could not easily pipe results with cli tools or anything like that. This changes the results to be output to json to make it easier to use and more similiar to what people expect.

This had one annoyance because since our structs are generated using prost, we cannot just simply add the serde traits to the structs, so instead we recreate the types we are going to output in the cli and covert them. There are a couple places where I just created "empty" default versions of types because we had to handle the `None` case because of how proto handles structs, not totally sure if this is the best move or if we should do something like an `unreachable` instead