### PR TITLE
Move endpoint path constants to shared defintion

### DIFF
--- a/ldk-server-client/src/client.rs
+++ b/ldk-server-client/src/client.rs
@@ -13,25 +13,17 @@ use ldk_server_protos::api::{
 	OnchainReceiveRequest, OnchainReceiveResponse, OnchainSendRequest, OnchainSendResponse,
 	OpenChannelRequest, OpenChannelResponse,
 };
+use ldk_server_protos::endpoints::{
+	BOLT11_RECEIVE_PATH, BOLT11_SEND_PATH, BOLT12_RECEIVE_PATH, BOLT12_SEND_PATH,
+	CLOSE_CHANNEL_PATH, FORCE_CLOSE_CHANNEL_PATH, GET_BALANCES_PATH, GET_NODE_INFO_PATH,
+	LIST_CHANNELS_PATH, LIST_PAYMENTS_PATH, ONCHAIN_RECEIVE_PATH, ONCHAIN_SEND_PATH,
+	OPEN_CHANNEL_PATH,
+};
 use ldk_server_protos::error::{ErrorCode, ErrorResponse};
 use reqwest::header::CONTENT_TYPE;
 use reqwest::Client;
 
 const APPLICATION_OCTET_STREAM: &str = "application/octet-stream";
-
-const GET_NODE_INFO_PATH: &str = "GetNodeInfo";
-const GET_BALANCES_PATH: &str = "GetBalances";
-const ONCHAIN_RECEIVE_PATH: &str = "OnchainReceive";
-const ONCHAIN_SEND_PATH: &str = "OnchainSend";
-const BOLT11_RECEIVE_PATH: &str = "Bolt11Receive";
-const BOLT11_SEND_PATH: &str = "Bolt11Send";
-const BOLT12_RECEIVE_PATH: &str = "Bolt12Receive";
-const BOLT12_SEND_PATH: &str = "Bolt12Send";
-const OPEN_CHANNEL_PATH: &str = "OpenChannel";
-const CLOSE_CHANNEL_PATH: &str = "CloseChannel";
-const FORCE_CLOSE_CHANNEL_PATH: &str = "ForceCloseChannel";
-const LIST_CHANNELS_PATH: &str = "ListChannels";
-const LIST_PAYMENTS_PATH: &str = "ListPayments";
 
 /// Client to access a hosted instance of LDK Server.
 #[derive(Clone)]

--- a/ldk-server-protos/src/endpoints.rs
+++ b/ldk-server-protos/src/endpoints.rs
@@ -1,0 +1,16 @@
+pub const GET_NODE_INFO_PATH: &str = "GetNodeInfo";
+pub const GET_BALANCES_PATH: &str = "GetBalances";
+pub const ONCHAIN_RECEIVE_PATH: &str = "OnchainReceive";
+pub const ONCHAIN_SEND_PATH: &str = "OnchainSend";
+pub const BOLT11_RECEIVE_PATH: &str = "Bolt11Receive";
+pub const BOLT11_SEND_PATH: &str = "Bolt11Send";
+pub const BOLT12_RECEIVE_PATH: &str = "Bolt12Receive";
+pub const BOLT12_SEND_PATH: &str = "Bolt12Send";
+pub const OPEN_CHANNEL_PATH: &str = "OpenChannel";
+pub const CLOSE_CHANNEL_PATH: &str = "CloseChannel";
+pub const FORCE_CLOSE_CHANNEL_PATH: &str = "ForceCloseChannel";
+pub const LIST_CHANNELS_PATH: &str = "ListChannels";
+pub const LIST_PAYMENTS_PATH: &str = "ListPayments";
+pub const LIST_FORWARDED_PAYMENTS_PATH: &str = "ListForwardedPayments";
+pub const UPDATE_CHANNEL_CONFIG_PATH: &str = "UpdateChannelConfig";
+pub const GET_PAYMENT_DETAILS_PATH: &str = "GetPaymentDetails";

--- a/ldk-server-protos/src/lib.rs
+++ b/ldk-server-protos/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod api;
+pub mod endpoints;
 pub mod error;
 pub mod events;
 pub mod types;

--- a/ldk-server/src/api/bolt11_receive.rs
+++ b/ldk-server/src/api/bolt11_receive.rs
@@ -3,8 +3,6 @@ use crate::service::Context;
 use crate::util::proto_adapter::proto_to_bolt11_description;
 use ldk_server_protos::api::{Bolt11ReceiveRequest, Bolt11ReceiveResponse};
 
-pub(crate) const BOLT11_RECEIVE_PATH: &str = "Bolt11Receive";
-
 pub(crate) fn handle_bolt11_receive_request(
 	context: Context, request: Bolt11ReceiveRequest,
 ) -> Result<Bolt11ReceiveResponse, LdkServerError> {

--- a/ldk-server/src/api/bolt11_send.rs
+++ b/ldk-server/src/api/bolt11_send.rs
@@ -4,8 +4,6 @@ use ldk_node::lightning_invoice::Bolt11Invoice;
 use ldk_server_protos::api::{Bolt11SendRequest, Bolt11SendResponse};
 use std::str::FromStr;
 
-pub(crate) const BOLT11_SEND_PATH: &str = "Bolt11Send";
-
 pub(crate) fn handle_bolt11_send_request(
 	context: Context, request: Bolt11SendRequest,
 ) -> Result<Bolt11SendResponse, LdkServerError> {

--- a/ldk-server/src/api/bolt12_receive.rs
+++ b/ldk-server/src/api/bolt12_receive.rs
@@ -2,8 +2,6 @@ use crate::api::error::LdkServerError;
 use crate::service::Context;
 use ldk_server_protos::api::{Bolt12ReceiveRequest, Bolt12ReceiveResponse};
 
-pub(crate) const BOLT12_RECEIVE_PATH: &str = "Bolt12Receive";
-
 pub(crate) fn handle_bolt12_receive_request(
 	context: Context, request: Bolt12ReceiveRequest,
 ) -> Result<Bolt12ReceiveResponse, LdkServerError> {

--- a/ldk-server/src/api/bolt12_send.rs
+++ b/ldk-server/src/api/bolt12_send.rs
@@ -4,8 +4,6 @@ use ldk_node::lightning::offers::offer::Offer;
 use ldk_server_protos::api::{Bolt12SendRequest, Bolt12SendResponse};
 use std::str::FromStr;
 
-pub(crate) const BOLT12_SEND_PATH: &str = "Bolt12Send";
-
 pub(crate) fn handle_bolt12_send_request(
 	context: Context, request: Bolt12SendRequest,
 ) -> Result<Bolt12SendResponse, LdkServerError> {

--- a/ldk-server/src/api/close_channel.rs
+++ b/ldk-server/src/api/close_channel.rs
@@ -8,8 +8,6 @@ use ldk_server_protos::api::{
 };
 use std::str::FromStr;
 
-pub(crate) const CLOSE_CHANNEL_PATH: &str = "CloseChannel";
-
 pub(crate) fn handle_close_channel_request(
 	context: Context, request: CloseChannelRequest,
 ) -> Result<CloseChannelResponse, LdkServerError> {
@@ -20,8 +18,6 @@ pub(crate) fn handle_close_channel_request(
 
 	Ok(CloseChannelResponse {})
 }
-
-pub(crate) const FORCE_CLOSE_CHANNEL_PATH: &str = "ForceCloseChannel";
 
 pub(crate) fn handle_force_close_channel_request(
 	context: Context, request: ForceCloseChannelRequest,

--- a/ldk-server/src/api/get_balances.rs
+++ b/ldk-server/src/api/get_balances.rs
@@ -3,8 +3,6 @@ use crate::service::Context;
 use crate::util::proto_adapter::{lightning_balance_to_proto, pending_sweep_balance_to_proto};
 use ldk_server_protos::api::{GetBalancesRequest, GetBalancesResponse};
 
-pub(crate) const GET_BALANCES: &str = "GetBalances";
-
 pub(crate) fn handle_get_balances_request(
 	context: Context, _request: GetBalancesRequest,
 ) -> Result<GetBalancesResponse, LdkServerError> {

--- a/ldk-server/src/api/get_node_info.rs
+++ b/ldk-server/src/api/get_node_info.rs
@@ -3,8 +3,6 @@ use crate::service::Context;
 use ldk_server_protos::api::{GetNodeInfoRequest, GetNodeInfoResponse};
 use ldk_server_protos::types::BestBlock;
 
-pub(crate) const GET_NODE_INFO: &str = "GetNodeInfo";
-
 pub(crate) fn handle_get_node_info_request(
 	context: Context, _request: GetNodeInfoRequest,
 ) -> Result<GetNodeInfoResponse, LdkServerError> {

--- a/ldk-server/src/api/get_payment_details.rs
+++ b/ldk-server/src/api/get_payment_details.rs
@@ -6,8 +6,6 @@ use hex::FromHex;
 use ldk_node::lightning::ln::channelmanager::PaymentId;
 use ldk_server_protos::api::{GetPaymentDetailsRequest, GetPaymentDetailsResponse};
 
-pub(crate) const GET_PAYMENT_DETAILS_PATH: &str = "GetPaymentDetails";
-
 pub(crate) fn handle_get_payment_details_request(
 	context: Context, request: GetPaymentDetailsRequest,
 ) -> Result<GetPaymentDetailsResponse, LdkServerError> {

--- a/ldk-server/src/api/list_channels.rs
+++ b/ldk-server/src/api/list_channels.rs
@@ -3,8 +3,6 @@ use crate::service::Context;
 use crate::util::proto_adapter::channel_to_proto;
 use ldk_server_protos::api::{ListChannelsRequest, ListChannelsResponse};
 
-pub(crate) const LIST_CHANNELS_PATH: &str = "ListChannels";
-
 pub(crate) fn handle_list_channels_request(
 	context: Context, _request: ListChannelsRequest,
 ) -> Result<ListChannelsResponse, LdkServerError> {

--- a/ldk-server/src/api/list_forwarded_payments.rs
+++ b/ldk-server/src/api/list_forwarded_payments.rs
@@ -10,8 +10,6 @@ use ldk_server_protos::api::{ListForwardedPaymentsRequest, ListForwardedPayments
 use ldk_server_protos::types::{ForwardedPayment, PageToken};
 use prost::Message;
 
-pub(crate) const LIST_FORWARDED_PAYMENTS_PATH: &str = "ListForwardedPayments";
-
 pub(crate) fn handle_list_forwarded_payments_request(
 	context: Context, request: ListForwardedPaymentsRequest,
 ) -> Result<ListForwardedPaymentsResponse, LdkServerError> {

--- a/ldk-server/src/api/list_payments.rs
+++ b/ldk-server/src/api/list_payments.rs
@@ -9,8 +9,6 @@ use ldk_server_protos::api::{ListPaymentsRequest, ListPaymentsResponse};
 use ldk_server_protos::types::{PageToken, Payment};
 use prost::Message;
 
-pub(crate) const LIST_PAYMENTS_PATH: &str = "ListPayments";
-
 pub(crate) fn handle_list_payments_request(
 	context: Context, request: ListPaymentsRequest,
 ) -> Result<ListPaymentsResponse, LdkServerError> {

--- a/ldk-server/src/api/onchain_receive.rs
+++ b/ldk-server/src/api/onchain_receive.rs
@@ -2,7 +2,6 @@ use crate::api::error::LdkServerError;
 use crate::service::Context;
 use ldk_server_protos::api::{OnchainReceiveRequest, OnchainReceiveResponse};
 
-pub(crate) const ONCHAIN_RECEIVE_PATH: &str = "OnchainReceive";
 pub(crate) fn handle_onchain_receive_request(
 	context: Context, _request: OnchainReceiveRequest,
 ) -> Result<OnchainReceiveResponse, LdkServerError> {

--- a/ldk-server/src/api/onchain_send.rs
+++ b/ldk-server/src/api/onchain_send.rs
@@ -5,8 +5,6 @@ use ldk_node::bitcoin::{Address, FeeRate};
 use ldk_server_protos::api::{OnchainSendRequest, OnchainSendResponse};
 use std::str::FromStr;
 
-pub(crate) const ONCHAIN_SEND_PATH: &str = "OnchainSend";
-
 pub(crate) fn handle_onchain_send_request(
 	context: Context, request: OnchainSendRequest,
 ) -> Result<OnchainSendResponse, LdkServerError> {

--- a/ldk-server/src/api/open_channel.rs
+++ b/ldk-server/src/api/open_channel.rs
@@ -5,8 +5,6 @@ use ldk_node::lightning::ln::msgs::SocketAddress;
 use ldk_server_protos::api::{OpenChannelRequest, OpenChannelResponse};
 use std::str::FromStr;
 
-pub(crate) const OPEN_CHANNEL_PATH: &str = "OpenChannel";
-
 pub(crate) fn handle_open_channel(
 	context: Context, request: OpenChannelRequest,
 ) -> Result<OpenChannelResponse, LdkServerError> {

--- a/ldk-server/src/api/update_channel_config.rs
+++ b/ldk-server/src/api/update_channel_config.rs
@@ -8,8 +8,6 @@ use ldk_server_protos::api::{UpdateChannelConfigRequest, UpdateChannelConfigResp
 use ldk_server_protos::types::channel_config::MaxDustHtlcExposure;
 use std::str::FromStr;
 
-pub(crate) const UPDATE_CHANNEL_CONFIG_PATH: &str = "UpdateChannelConfig";
-
 pub(crate) fn handle_update_channel_config_request(
 	context: Context, request: UpdateChannelConfigRequest,
 ) -> Result<UpdateChannelConfigResponse, LdkServerError> {

--- a/ldk-server/src/service.rs
+++ b/ldk-server/src/service.rs
@@ -5,34 +5,32 @@ use hyper::body::{Bytes, Incoming};
 use hyper::service::Service;
 use hyper::{Request, Response, StatusCode};
 
+use ldk_server_protos::endpoints::{
+	BOLT11_RECEIVE_PATH, BOLT11_SEND_PATH, BOLT12_RECEIVE_PATH, BOLT12_SEND_PATH,
+	CLOSE_CHANNEL_PATH, FORCE_CLOSE_CHANNEL_PATH, GET_BALANCES_PATH, GET_NODE_INFO_PATH,
+	GET_PAYMENT_DETAILS_PATH, LIST_CHANNELS_PATH, LIST_FORWARDED_PAYMENTS_PATH, LIST_PAYMENTS_PATH,
+	ONCHAIN_RECEIVE_PATH, ONCHAIN_SEND_PATH, OPEN_CHANNEL_PATH, UPDATE_CHANNEL_CONFIG_PATH,
+};
+
 use prost::Message;
 
-use crate::api::bolt11_receive::{handle_bolt11_receive_request, BOLT11_RECEIVE_PATH};
-use crate::api::bolt11_send::{handle_bolt11_send_request, BOLT11_SEND_PATH};
-use crate::api::bolt12_receive::{handle_bolt12_receive_request, BOLT12_RECEIVE_PATH};
-use crate::api::bolt12_send::{handle_bolt12_send_request, BOLT12_SEND_PATH};
-use crate::api::close_channel::{
-	handle_close_channel_request, handle_force_close_channel_request, CLOSE_CHANNEL_PATH,
-	FORCE_CLOSE_CHANNEL_PATH,
-};
+use crate::api::bolt11_receive::handle_bolt11_receive_request;
+use crate::api::bolt11_send::handle_bolt11_send_request;
+use crate::api::bolt12_receive::handle_bolt12_receive_request;
+use crate::api::bolt12_send::handle_bolt12_send_request;
+use crate::api::close_channel::{handle_close_channel_request, handle_force_close_channel_request};
 use crate::api::error::LdkServerError;
 use crate::api::error::LdkServerErrorCode::InvalidRequestError;
-use crate::api::get_balances::{handle_get_balances_request, GET_BALANCES};
-use crate::api::get_node_info::{handle_get_node_info_request, GET_NODE_INFO};
-use crate::api::get_payment_details::{
-	handle_get_payment_details_request, GET_PAYMENT_DETAILS_PATH,
-};
-use crate::api::list_channels::{handle_list_channels_request, LIST_CHANNELS_PATH};
-use crate::api::list_forwarded_payments::{
-	handle_list_forwarded_payments_request, LIST_FORWARDED_PAYMENTS_PATH,
-};
-use crate::api::list_payments::{handle_list_payments_request, LIST_PAYMENTS_PATH};
-use crate::api::onchain_receive::{handle_onchain_receive_request, ONCHAIN_RECEIVE_PATH};
-use crate::api::onchain_send::{handle_onchain_send_request, ONCHAIN_SEND_PATH};
-use crate::api::open_channel::{handle_open_channel, OPEN_CHANNEL_PATH};
-use crate::api::update_channel_config::{
-	handle_update_channel_config_request, UPDATE_CHANNEL_CONFIG_PATH,
-};
+use crate::api::get_balances::handle_get_balances_request;
+use crate::api::get_node_info::handle_get_node_info_request;
+use crate::api::get_payment_details::handle_get_payment_details_request;
+use crate::api::list_channels::handle_list_channels_request;
+use crate::api::list_forwarded_payments::handle_list_forwarded_payments_request;
+use crate::api::list_payments::handle_list_payments_request;
+use crate::api::onchain_receive::handle_onchain_receive_request;
+use crate::api::onchain_send::handle_onchain_send_request;
+use crate::api::open_channel::handle_open_channel;
+use crate::api::update_channel_config::handle_update_channel_config_request;
 use crate::io::persist::paginated_kv_store::PaginatedKVStore;
 use crate::util::proto_adapter::to_error_response;
 use std::future::Future;
@@ -68,8 +66,12 @@ impl Service<Request<Incoming>> for NodeService {
 		};
 		// Exclude '/' from path pattern matching.
 		match &req.uri().path()[1..] {
-			GET_NODE_INFO => Box::pin(handle_request(context, req, handle_get_node_info_request)),
-			GET_BALANCES => Box::pin(handle_request(context, req, handle_get_balances_request)),
+			GET_NODE_INFO_PATH => {
+				Box::pin(handle_request(context, req, handle_get_node_info_request))
+			},
+			GET_BALANCES_PATH => {
+				Box::pin(handle_request(context, req, handle_get_balances_request))
+			},
 			ONCHAIN_RECEIVE_PATH => {
 				Box::pin(handle_request(context, req, handle_onchain_receive_request))
 			},


### PR DESCRIPTION
We had these defined in 2 separate areas which defeats the point of having them defined in constants. This moves them into the ldk-server-protos crate so they are shared among both the cli and server. Luckily there weren't any discrepancies.