### PR TITLE
Add HMAC-based authentication for RPC/CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1717,6 +1717,7 @@ name = "ldk-server"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "base64 0.21.7",
  "bytes",
  "chrono",
  "futures-util",
@@ -1751,6 +1752,7 @@ dependencies = [
 name = "ldk-server-client"
 version = "0.1.0"
 dependencies = [
+ "bitcoin_hashes 0.14.0",
  "ldk-server-protos",
  "prost",
  "reqwest 0.11.27",

--- a/README.md
+++ b/README.md
@@ -51,6 +51,6 @@ cargo run --bin ldk-server ./ldk-server/ldk-server-config.toml
 
 Interact with the node using CLI:
 ```
-./target/debug/ldk-server-cli -b localhost:3002 onchain-receive # To generate onchain-receive address.
-./target/debug/ldk-server-cli -b localhost:3002 help # To print help/available commands.
+./target/debug/ldk-server-cli -b localhost:3002 --api-key your-secret-api-key onchain-receive # To generate onchain-receive address.
+./target/debug/ldk-server-cli -b localhost:3002 --api-key your-secret-api-key help # To print help/available commands.
 ```

--- a/ldk-server-cli/src/main.rs
+++ b/ldk-server-cli/src/main.rs
@@ -46,6 +46,9 @@ struct Cli {
 	#[arg(short, long, default_value = "localhost:3000")]
 	base_url: String,
 
+	#[arg(short, long, required(true))]
+	api_key: String,
+
 	#[command(subcommand)]
 	command: Commands,
 }
@@ -214,7 +217,7 @@ enum Commands {
 #[tokio::main]
 async fn main() {
 	let cli = Cli::parse();
-	let client = LdkServerClient::new(cli.base_url);
+	let client = LdkServerClient::new(cli.base_url, cli.api_key);
 
 	match cli.command {
 		Commands::GetNodeInfo => {

--- a/ldk-server-client/Cargo.toml
+++ b/ldk-server-client/Cargo.toml
@@ -11,3 +11,4 @@ serde = ["ldk-server-protos/serde"]
 ldk-server-protos = { path = "../ldk-server-protos" }
 reqwest = { version = "0.11.13", default-features = false, features = ["rustls-tls"] }
 prost = { version = "0.11.6", default-features = false, features = ["std", "prost-derive"] }
+bitcoin_hashes = "0.14"

--- a/ldk-server/Cargo.toml
+++ b/ldk-server/Cargo.toml
@@ -20,6 +20,7 @@ async-trait = { version = "0.1.85", default-features = false }
 toml = { version = "0.8.9", default-features = false, features = ["parse"] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 log = "0.4.28"
+base64 = { version = "0.21", default-features = false, features = ["std"] }
 
 # Required for RabittMQ based EventPublisher. Only enabled for `events-rabbitmq` feature.
 lapin = { version = "2.4.0", features = ["rustls"], default-features = false, optional = true }

--- a/ldk-server/ldk-server-config.toml
+++ b/ldk-server/ldk-server-config.toml
@@ -3,6 +3,7 @@
 network = "regtest"                           # Bitcoin network to use
 listening_address = "localhost:3001"          # Lightning node listening address
 rest_service_address = "127.0.0.1:3002"       # LDK Server REST address
+api_key = "your-secret-api-key"               # API key for authenticating REST requests
 
 # Storage settings
 [storage.disk]

--- a/ldk-server/src/api/error.rs
+++ b/ldk-server/src/api/error.rs
@@ -43,6 +43,9 @@ pub(crate) enum LdkServerErrorCode {
 	/// Please refer to [`protos::error::ErrorCode::InvalidRequestError`].
 	InvalidRequestError,
 
+	/// Please refer to [`protos::error::ErrorCode::AuthError`].
+	AuthError,
+
 	/// Please refer to [`protos::error::ErrorCode::LightningError`].
 	LightningError,
 
@@ -54,6 +57,7 @@ impl fmt::Display for LdkServerErrorCode {
 	fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
 		match self {
 			LdkServerErrorCode::InvalidRequestError => write!(f, "InvalidRequestError"),
+			LdkServerErrorCode::AuthError => write!(f, "AuthError"),
 			LdkServerErrorCode::LightningError => write!(f, "LightningError"),
 			LdkServerErrorCode::InternalServerError => write!(f, "InternalServerError"),
 		}

--- a/ldk-server/src/main.rs
+++ b/ldk-server/src/main.rs
@@ -356,7 +356,7 @@ fn main() {
 					match res {
 						Ok((stream, _)) => {
 							let io_stream = TokioIo::new(stream);
-							let node_service = NodeService::new(Arc::clone(&node), Arc::clone(&paginated_store));
+							let node_service = NodeService::new(Arc::clone(&node), Arc::clone(&paginated_store), config_file.api_key.clone());
 							runtime.spawn(async move {
 								if let Err(err) = http1::Builder::new().serve_connection(io_stream, node_service).await {
 									error!("Failed to serve connection: {}", err);

--- a/ldk-server/src/service.rs
+++ b/ldk-server/src/service.rs
@@ -7,6 +7,8 @@
 // You may not use this file except in accordance with one or both of these
 // licenses.
 
+use ldk_node::bitcoin::hashes::hmac::{Hmac, HmacEngine};
+use ldk_node::bitcoin::hashes::{sha256, Hash, HashEngine};
 use ldk_node::Node;
 
 use http_body_util::{BodyExt, Full, Limited};
@@ -30,7 +32,7 @@ use crate::api::bolt12_receive::handle_bolt12_receive_request;
 use crate::api::bolt12_send::handle_bolt12_send_request;
 use crate::api::close_channel::{handle_close_channel_request, handle_force_close_channel_request};
 use crate::api::error::LdkServerError;
-use crate::api::error::LdkServerErrorCode::InvalidRequestError;
+use crate::api::error::LdkServerErrorCode::{AuthError, InvalidRequestError};
 use crate::api::get_balances::handle_get_balances_request;
 use crate::api::get_node_info::handle_get_node_info_request;
 use crate::api::get_payment_details::handle_get_payment_details_request;
@@ -56,12 +58,84 @@ const MAX_BODY_SIZE: usize = 10 * 1024 * 1024;
 pub struct NodeService {
 	node: Arc<Node>,
 	paginated_kv_store: Arc<dyn PaginatedKVStore>,
+	api_key: String,
 }
 
 impl NodeService {
-	pub(crate) fn new(node: Arc<Node>, paginated_kv_store: Arc<dyn PaginatedKVStore>) -> Self {
-		Self { node, paginated_kv_store }
+	pub(crate) fn new(
+		node: Arc<Node>, paginated_kv_store: Arc<dyn PaginatedKVStore>, api_key: String,
+	) -> Self {
+		Self { node, paginated_kv_store, api_key }
 	}
+}
+
+// Maximum allowed time difference between client timestamp and server time (1 minute)
+const AUTH_TIMESTAMP_TOLERANCE_SECS: u64 = 60;
+
+#[derive(Debug, Clone)]
+pub(crate) struct AuthParams {
+	timestamp: u64,
+	hmac_hex: String,
+}
+
+/// Extracts authentication parameters from request headers.
+/// Returns (timestamp, hmac_hex) if valid format, or error.
+fn extract_auth_params<B>(req: &Request<B>) -> Result<AuthParams, LdkServerError> {
+	let auth_header = req
+		.headers()
+		.get("X-Auth")
+		.and_then(|v| v.to_str().ok())
+		.ok_or_else(|| LdkServerError::new(AuthError, "Missing X-Auth header"))?;
+
+	// Format: "HMAC <timestamp>:<hmac_hex>"
+	let auth_data = auth_header
+		.strip_prefix("HMAC ")
+		.ok_or_else(|| LdkServerError::new(AuthError, "Invalid X-Auth header format"))?;
+
+	let (timestamp_str, hmac_hex) = auth_data
+		.split_once(':')
+		.ok_or_else(|| LdkServerError::new(AuthError, "Invalid X-Auth header format"))?;
+
+	let timestamp = timestamp_str
+		.parse::<u64>()
+		.map_err(|_| LdkServerError::new(AuthError, "Invalid timestamp in X-Auth header"))?;
+
+	// validate hmac_hex is valid hex
+	if hmac_hex.len() != 64 || !hmac_hex.chars().all(|c| c.is_ascii_hexdigit()) {
+		return Err(LdkServerError::new(AuthError, "Invalid HMAC in X-Auth header"));
+	}
+
+	Ok(AuthParams { timestamp, hmac_hex: hmac_hex.to_string() })
+}
+
+/// Validates the HMAC authentication after the request body has been read.
+fn validate_hmac_auth(
+	timestamp: u64, provided_hmac_hex: &str, body: &[u8], api_key: &str,
+) -> Result<(), LdkServerError> {
+	// Validate timestamp is within acceptable window
+	let now = std::time::SystemTime::now()
+		.duration_since(std::time::UNIX_EPOCH)
+		.map_err(|_| LdkServerError::new(AuthError, "System time error"))?
+		.as_secs();
+
+	let time_diff = now.abs_diff(timestamp);
+	if time_diff > AUTH_TIMESTAMP_TOLERANCE_SECS {
+		return Err(LdkServerError::new(AuthError, "Request timestamp expired"));
+	}
+
+	// Compute expected HMAC: HMAC-SHA256(api_key, timestamp_bytes || body)
+	let mut hmac_engine: HmacEngine<sha256::Hash> = HmacEngine::new(api_key.as_bytes());
+	hmac_engine.input(&timestamp.to_be_bytes());
+	hmac_engine.input(body);
+	let expected_hmac = Hmac::<sha256::Hash>::from_engine(hmac_engine);
+
+	// Compare HMACs (constant-time comparison via Hash equality)
+	let expected_hex = expected_hmac.to_string();
+	if expected_hex != provided_hmac_hex {
+		return Err(LdkServerError::new(AuthError, "Invalid credentials"));
+	}
+
+	Ok(())
 }
 
 pub(crate) struct Context {
@@ -75,56 +149,151 @@ impl Service<Request<Incoming>> for NodeService {
 	type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
 
 	fn call(&self, req: Request<Incoming>) -> Self::Future {
+		// Extract auth params from headers (validation happens after body is read)
+		let auth_params = match extract_auth_params(&req) {
+			Ok(params) => params,
+			Err(e) => {
+				let (error_response, status_code) = to_error_response(e);
+				return Box::pin(async move {
+					Ok(Response::builder()
+						.status(status_code)
+						.body(Full::new(Bytes::from(error_response.encode_to_vec())))
+						// unwrap safety: body only errors when previous chained calls failed.
+						.unwrap())
+				});
+			},
+		};
+
 		let context = Context {
 			node: Arc::clone(&self.node),
 			paginated_kv_store: Arc::clone(&self.paginated_kv_store),
 		};
+		let api_key = self.api_key.clone();
+
 		// Exclude '/' from path pattern matching.
 		match &req.uri().path()[1..] {
-			GET_NODE_INFO_PATH => {
-				Box::pin(handle_request(context, req, handle_get_node_info_request))
+			GET_NODE_INFO_PATH => Box::pin(handle_request(
+				context,
+				req,
+				auth_params,
+				api_key,
+				handle_get_node_info_request,
+			)),
+			GET_BALANCES_PATH => Box::pin(handle_request(
+				context,
+				req,
+				auth_params,
+				api_key,
+				handle_get_balances_request,
+			)),
+			ONCHAIN_RECEIVE_PATH => Box::pin(handle_request(
+				context,
+				req,
+				auth_params,
+				api_key,
+				handle_onchain_receive_request,
+			)),
+			ONCHAIN_SEND_PATH => Box::pin(handle_request(
+				context,
+				req,
+				auth_params,
+				api_key,
+				handle_onchain_send_request,
+			)),
+			BOLT11_RECEIVE_PATH => Box::pin(handle_request(
+				context,
+				req,
+				auth_params,
+				api_key,
+				handle_bolt11_receive_request,
+			)),
+			BOLT11_SEND_PATH => Box::pin(handle_request(
+				context,
+				req,
+				auth_params,
+				api_key,
+				handle_bolt11_send_request,
+			)),
+			BOLT12_RECEIVE_PATH => Box::pin(handle_request(
+				context,
+				req,
+				auth_params,
+				api_key,
+				handle_bolt12_receive_request,
+			)),
+			BOLT12_SEND_PATH => Box::pin(handle_request(
+				context,
+				req,
+				auth_params,
+				api_key,
+				handle_bolt12_send_request,
+			)),
+			OPEN_CHANNEL_PATH => {
+				Box::pin(handle_request(context, req, auth_params, api_key, handle_open_channel))
 			},
-			GET_BALANCES_PATH => {
-				Box::pin(handle_request(context, req, handle_get_balances_request))
-			},
-			ONCHAIN_RECEIVE_PATH => {
-				Box::pin(handle_request(context, req, handle_onchain_receive_request))
-			},
-			ONCHAIN_SEND_PATH => {
-				Box::pin(handle_request(context, req, handle_onchain_send_request))
-			},
-			BOLT11_RECEIVE_PATH => {
-				Box::pin(handle_request(context, req, handle_bolt11_receive_request))
-			},
-			BOLT11_SEND_PATH => Box::pin(handle_request(context, req, handle_bolt11_send_request)),
-			BOLT12_RECEIVE_PATH => {
-				Box::pin(handle_request(context, req, handle_bolt12_receive_request))
-			},
-			BOLT12_SEND_PATH => Box::pin(handle_request(context, req, handle_bolt12_send_request)),
-			OPEN_CHANNEL_PATH => Box::pin(handle_request(context, req, handle_open_channel)),
-			SPLICE_IN_PATH => Box::pin(handle_request(context, req, handle_splice_in_request)),
-			SPLICE_OUT_PATH => Box::pin(handle_request(context, req, handle_splice_out_request)),
-			CLOSE_CHANNEL_PATH => {
-				Box::pin(handle_request(context, req, handle_close_channel_request))
-			},
-			FORCE_CLOSE_CHANNEL_PATH => {
-				Box::pin(handle_request(context, req, handle_force_close_channel_request))
-			},
-			LIST_CHANNELS_PATH => {
-				Box::pin(handle_request(context, req, handle_list_channels_request))
-			},
-			UPDATE_CHANNEL_CONFIG_PATH => {
-				Box::pin(handle_request(context, req, handle_update_channel_config_request))
-			},
-			GET_PAYMENT_DETAILS_PATH => {
-				Box::pin(handle_request(context, req, handle_get_payment_details_request))
-			},
-			LIST_PAYMENTS_PATH => {
-				Box::pin(handle_request(context, req, handle_list_payments_request))
-			},
-			LIST_FORWARDED_PAYMENTS_PATH => {
-				Box::pin(handle_request(context, req, handle_list_forwarded_payments_request))
-			},
+			SPLICE_IN_PATH => Box::pin(handle_request(
+				context,
+				req,
+				auth_params,
+				api_key,
+				handle_splice_in_request,
+			)),
+			SPLICE_OUT_PATH => Box::pin(handle_request(
+				context,
+				req,
+				auth_params,
+				api_key,
+				handle_splice_out_request,
+			)),
+			CLOSE_CHANNEL_PATH => Box::pin(handle_request(
+				context,
+				req,
+				auth_params,
+				api_key,
+				handle_close_channel_request,
+			)),
+			FORCE_CLOSE_CHANNEL_PATH => Box::pin(handle_request(
+				context,
+				req,
+				auth_params,
+				api_key,
+				handle_force_close_channel_request,
+			)),
+			LIST_CHANNELS_PATH => Box::pin(handle_request(
+				context,
+				req,
+				auth_params,
+				api_key,
+				handle_list_channels_request,
+			)),
+			UPDATE_CHANNEL_CONFIG_PATH => Box::pin(handle_request(
+				context,
+				req,
+				auth_params,
+				api_key,
+				handle_update_channel_config_request,
+			)),
+			GET_PAYMENT_DETAILS_PATH => Box::pin(handle_request(
+				context,
+				req,
+				auth_params,
+				api_key,
+				handle_get_payment_details_request,
+			)),
+			LIST_PAYMENTS_PATH => Box::pin(handle_request(
+				context,
+				req,
+				auth_params,
+				api_key,
+				handle_list_payments_request,
+			)),
+			LIST_FORWARDED_PAYMENTS_PATH => Box::pin(handle_request(
+				context,
+				req,
+				auth_params,
+				api_key,
+				handle_list_forwarded_payments_request,
+			)),
 			path => {
 				let error = format!("Unknown request: {}", path).into_bytes();
 				Box::pin(async {
@@ -144,7 +313,8 @@ async fn handle_request<
 	R: Message,
 	F: Fn(Context, T) -> Result<R, LdkServerError>,
 >(
-	context: Context, request: Request<Incoming>, handler: F,
+	context: Context, request: Request<Incoming>, auth_params: AuthParams, api_key: String,
+	handler: F,
 ) -> Result<<NodeService as Service<Request<Incoming>>>::Response, hyper::Error> {
 	// Limit the size of the request body to prevent abuse
 	let limited_body = Limited::new(request.into_body(), MAX_BODY_SIZE);
@@ -162,6 +332,18 @@ async fn handle_request<
 				.unwrap());
 		},
 	};
+
+	// Validate HMAC authentication with the request body
+	if let Err(e) =
+		validate_hmac_auth(auth_params.timestamp, &auth_params.hmac_hex, &bytes, &api_key)
+	{
+		let (error_response, status_code) = to_error_response(e);
+		return Ok(Response::builder()
+			.status(status_code)
+			.body(Full::new(Bytes::from(error_response.encode_to_vec())))
+			// unwrap safety: body only errors when previous chained calls failed.
+			.unwrap());
+	}
 
 	match T::decode(bytes) {
 		Ok(request) => match handler(context, request) {
@@ -187,5 +369,117 @@ async fn handle_request<
 				// unwrap safety: body only errors when previous chained calls failed.
 				.unwrap())
 		},
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	fn compute_hmac(api_key: &str, timestamp: u64, body: &[u8]) -> String {
+		let mut hmac_engine: HmacEngine<sha256::Hash> = HmacEngine::new(api_key.as_bytes());
+		hmac_engine.input(&timestamp.to_be_bytes());
+		hmac_engine.input(body);
+		Hmac::<sha256::Hash>::from_engine(hmac_engine).to_string()
+	}
+
+	fn create_test_request(auth_header: Option<String>) -> Request<()> {
+		let mut builder = Request::builder();
+		if let Some(header) = auth_header {
+			builder = builder.header("X-Auth", header);
+		}
+		builder.body(()).unwrap()
+	}
+
+	#[test]
+	fn test_extract_auth_params_success() {
+		let timestamp =
+			std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_secs();
+		let hmac = "8f5a33c2c68fb253899a588308fd13dcaf162d2788966a1fb6cc3aa2e0c51a93";
+		let auth_header = format!("HMAC {timestamp}:{hmac}");
+
+		let req = create_test_request(Some(auth_header));
+
+		let result = extract_auth_params(&req);
+		assert!(result.is_ok());
+		let AuthParams { timestamp: ts, hmac_hex } = result.unwrap();
+		assert_eq!(ts, timestamp);
+		assert_eq!(hmac_hex, hmac);
+	}
+
+	#[test]
+	fn test_extract_auth_params_missing_header() {
+		let req = create_test_request(None);
+
+		let result = extract_auth_params(&req);
+		assert!(result.is_err());
+		assert_eq!(result.unwrap_err().error_code, AuthError);
+	}
+
+	#[test]
+	fn test_extract_auth_params_invalid_format() {
+		// Missing "HMAC " prefix
+		let req = create_test_request(Some("12345:deadbeef".to_string()));
+
+		let result = extract_auth_params(&req);
+		assert!(result.is_err());
+		assert_eq!(result.unwrap_err().error_code, AuthError);
+	}
+
+	#[test]
+	fn test_validate_hmac_auth_success() {
+		let api_key = "test_api_key".to_string();
+		let body = b"test request body";
+		let timestamp =
+			std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_secs();
+		let hmac = compute_hmac(&api_key, timestamp, body);
+
+		let result = validate_hmac_auth(timestamp, &hmac, body, &api_key);
+		assert!(result.is_ok());
+	}
+
+	#[test]
+	fn test_validate_hmac_auth_wrong_key() {
+		let api_key = "test_api_key".to_string();
+		let body = b"test request body";
+		let timestamp =
+			std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_secs();
+		// Compute HMAC with wrong key
+		let hmac = compute_hmac("wrong_key", timestamp, body);
+
+		let result = validate_hmac_auth(timestamp, &hmac, body, &api_key);
+		assert!(result.is_err());
+		assert_eq!(result.unwrap_err().error_code, AuthError);
+	}
+
+	#[test]
+	fn test_validate_hmac_auth_expired_timestamp() {
+		let api_key = "test_api_key".to_string();
+		let body = b"test request body";
+		// Use a timestamp from 10 minutes ago
+		let timestamp =
+			std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_secs()
+				- 600;
+		let hmac = compute_hmac(&api_key, timestamp, body);
+
+		let result = validate_hmac_auth(timestamp, &hmac, body, &api_key);
+		assert!(result.is_err());
+		assert_eq!(result.unwrap_err().error_code, AuthError);
+	}
+
+	#[test]
+	fn test_validate_hmac_auth_tampered_body() {
+		let api_key = "test_api_key".to_string();
+		let original_body = b"test request body";
+		let tampered_body = b"tampered body";
+		let timestamp =
+			std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_secs();
+		// Compute HMAC with original body
+		let hmac = compute_hmac(&api_key, timestamp, original_body);
+
+		// Try to validate with tampered body
+		let result = validate_hmac_auth(timestamp, &hmac, tampered_body, &api_key);
+		assert!(result.is_err());
+		assert_eq!(result.unwrap_err().error_code, AuthError);
 	}
 }

--- a/ldk-server/src/util/config.rs
+++ b/ldk-server/src/util/config.rs
@@ -24,6 +24,7 @@ pub struct Config {
 	pub listening_addr: SocketAddress,
 	pub alias: Option<NodeAlias>,
 	pub network: Network,
+	pub api_key: String,
 	pub rest_service_addr: SocketAddr,
 	pub storage_dir_path: String,
 	pub chain_source: ChainSource,
@@ -149,6 +150,7 @@ impl TryFrom<TomlConfig> for Config {
 			network: toml_config.node.network,
 			alias,
 			rest_service_addr,
+			api_key: toml_config.node.api_key,
 			storage_dir_path: toml_config.storage.disk.dir_path,
 			chain_source,
 			rabbitmq_connection_string,
@@ -179,6 +181,7 @@ struct NodeConfig {
 	listening_address: String,
 	rest_service_address: String,
 	alias: Option<String>,
+	api_key: String,
 }
 
 #[derive(Deserialize, Serialize)]
@@ -304,17 +307,18 @@ mod tests {
 			listening_address = "localhost:3001"
 			rest_service_address = "127.0.0.1:3002"
 			alias = "LDK Server"
-			
+			api_key = "test_api_key"
+
 			[storage.disk]
 			dir_path = "/tmp"
 
 			[log]
 			level = "Trace"
 			file = "/var/log/ldk-server.log"
-			
+
 			[esplora]
 			server_url = "https://mempool.space/api"
-			
+
 			[rabbitmq]
 			connection_string = "rabbitmq_connection_string"
 			exchange_name = "rabbitmq_exchange_name"
@@ -343,6 +347,7 @@ mod tests {
 			alias: Some(NodeAlias(bytes)),
 			network: Network::Regtest,
 			rest_service_addr: SocketAddr::from_str("127.0.0.1:3002").unwrap(),
+			api_key: "test_api_key".to_string(),
 			storage_dir_path: "/tmp".to_string(),
 			chain_source: ChainSource::Esplora {
 				server_url: String::from("https://mempool.space/api"),
@@ -368,6 +373,7 @@ mod tests {
 		assert_eq!(config.listening_addr, expected.listening_addr);
 		assert_eq!(config.network, expected.network);
 		assert_eq!(config.rest_service_addr, expected.rest_service_addr);
+		assert_eq!(config.api_key, expected.api_key);
 		assert_eq!(config.storage_dir_path, expected.storage_dir_path);
 		let ChainSource::Esplora { server_url } = config.chain_source else {
 			panic!("unexpected config chain source");
@@ -389,21 +395,22 @@ mod tests {
 			listening_address = "localhost:3001"
 			rest_service_address = "127.0.0.1:3002"
 			alias = "LDK Server"
-			
+			api_key = "test_api_key"
+
 			[storage.disk]
 			dir_path = "/tmp"
 
 			[log]
 			level = "Trace"
 			file = "/var/log/ldk-server.log"
-			
+
 			[electrum]
 			server_url = "ssl://electrum.blockstream.info:50002"
-			
+
 			[rabbitmq]
 			connection_string = "rabbitmq_connection_string"
 			exchange_name = "rabbitmq_exchange_name"
-			
+
 			[liquidity.lsps2_service]
 			advertise_service = false
 			channel_opening_fee_ppm = 1000            # 0.1% fee
@@ -433,19 +440,20 @@ mod tests {
 			listening_address = "localhost:3001"
 			rest_service_address = "127.0.0.1:3002"
 			alias = "LDK Server"
-			
+			api_key = "test_api_key"
+
 			[storage.disk]
 			dir_path = "/tmp"
 
 			[log]
 			level = "Trace"
 			file = "/var/log/ldk-server.log"
-			
+
 			[bitcoind]
 			rpc_address = "127.0.0.1:8332"    # RPC endpoint
 			rpc_user = "bitcoind-testuser"
 			rpc_password = "bitcoind-testpassword"
-			
+
 			[rabbitmq]
 			connection_string = "rabbitmq_connection_string"
 			exchange_name = "rabbitmq_exchange_name"
@@ -481,22 +489,23 @@ mod tests {
 			listening_address = "localhost:3001"
 			rest_service_address = "127.0.0.1:3002"
 			alias = "LDK Server"
-			
+			api_key = "test_api_key"
+
 			[storage.disk]
 			dir_path = "/tmp"
 
 			[log]
 			level = "Trace"
 			file = "/var/log/ldk-server.log"
-			
+
 			[bitcoind]
 			rpc_address = "127.0.0.1:8332"    # RPC endpoint
 			rpc_user = "bitcoind-testuser"
 			rpc_password = "bitcoind-testpassword"
-			
+
 			[esplora]
 			server_url = "https://mempool.space/api"
-			
+
 			[rabbitmq]
 			connection_string = "rabbitmq_connection_string"
 			exchange_name = "rabbitmq_exchange_name"

--- a/ldk-server/src/util/proto_adapter.rs
+++ b/ldk-server/src/util/proto_adapter.rs
@@ -9,7 +9,7 @@
 
 use crate::api::error::LdkServerError;
 use crate::api::error::LdkServerErrorCode::{
-	InternalServerError, InvalidRequestError, LightningError,
+	AuthError, InternalServerError, InvalidRequestError, LightningError,
 };
 use bytes::Bytes;
 use hex::prelude::*;
@@ -443,12 +443,14 @@ pub(crate) fn proto_to_bolt11_description(
 pub(crate) fn to_error_response(ldk_error: LdkServerError) -> (ErrorResponse, StatusCode) {
 	let error_code = match ldk_error.error_code {
 		InvalidRequestError => ErrorCode::InvalidRequestError,
+		AuthError => ErrorCode::AuthError,
 		LightningError => ErrorCode::LightningError,
 		InternalServerError => ErrorCode::InternalServerError,
 	} as i32;
 
 	let status = match ldk_error.error_code {
 		InvalidRequestError => StatusCode::BAD_REQUEST,
+		AuthError => StatusCode::UNAUTHORIZED,
 		LightningError => StatusCode::INTERNAL_SERVER_ERROR,
 		InternalServerError => StatusCode::INTERNAL_SERVER_ERROR,
 	};


### PR DESCRIPTION
Implements time-based HMAC-SHA256 authentication using a shared API key.
Each request includes a timestamp and HMAC in the X-Auth header, preventing
replay attacks with a 60-second tolerance window.