### PR TITLE
Add TLS support for RPC/CLI 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1731,9 +1731,11 @@ dependencies = [
  "log",
  "prost",
  "rand 0.8.5",
+ "rcgen",
  "rusqlite",
  "serde",
  "tokio",
+ "tokio-rustls 0.26.4",
  "toml",
 ]
 
@@ -2524,6 +2526,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62c64daa8e9438b84aaae55010a93f396f8e60e3911590fcba770d04643fc1dd"
 dependencies = [
  "cipher",
+]
+
+[[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
 ]
 
 [[package]]
@@ -4037,6 +4051,15 @@ dependencies = [
  "oid-registry",
  "rusticata-macros",
  "thiserror",
+ "time",
+]
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
  "time",
 ]
 

--- a/ldk-server/Cargo.toml
+++ b/ldk-server/Cargo.toml
@@ -10,6 +10,8 @@ hyper = { version = "1", default-features = false, features = ["server", "http1"
 http-body-util = { version = "0.1", default-features = false }
 hyper-util = { version = "0.1", default-features = false, features = ["server-graceful"] }
 tokio = { version = "1.38.0", default-features = false, features = ["time", "signal", "rt-multi-thread"] }
+tokio-rustls = { version = "0.26", default-features = false, features = ["ring"] }
+rcgen = { version = "0.13", default-features = false, features = ["ring"] }
 prost = { version = "0.11.6", default-features = false, features = ["std"] }
 ldk-server-protos = { path = "../ldk-server-protos" }
 bytes = { version = "1.4.0", default-features = false }

--- a/ldk-server/ldk-server-config.toml
+++ b/ldk-server/ldk-server-config.toml
@@ -13,6 +13,11 @@ dir_path = "/tmp/ldk-server/"                 # Path for LDK and BDK data persis
 level = "Debug"                               # Log level (Error, Warn, Info, Debug, Trace)
 file_path = "/tmp/ldk-server/ldk-server.log"  # Log file path
 
+[tls]
+#cert_path = "/path/to/tls.crt"               # Path to TLS certificate, by default uses dir_path/tls.crt
+#key_path = "/path/to/tls.key"                # Path to TLS private key, by default uses dir_path/tls.key
+hosts = ["example.com"]                       # Allowed hosts for TLS, will always include "localhost" and "127.0.0.1"
+
 # Must set either bitcoind or esplora settings, but not both
 
 # Bitcoin Core settings

--- a/ldk-server/src/main.rs
+++ b/ldk-server/src/main.rs
@@ -36,6 +36,7 @@ use crate::io::persist::{
 use crate::util::config::{load_config, ChainSource};
 use crate::util::logger::ServerLogger;
 use crate::util::proto_adapter::{forwarded_payment_to_proto, payment_to_proto};
+use crate::util::tls::get_or_generate_tls_config;
 use hex::DisplayHex;
 use ldk_node::config::Config;
 use ldk_node::lightning::ln::channelmanager::PaymentId;
@@ -155,14 +156,15 @@ fn main() {
 		},
 	};
 
-	let paginated_store: Arc<dyn PaginatedKVStore> =
-		Arc::new(match SqliteStore::new(PathBuf::from(config_file.storage_dir_path), None, None) {
+	let paginated_store: Arc<dyn PaginatedKVStore> = Arc::new(
+		match SqliteStore::new(PathBuf::from(&config_file.storage_dir_path), None, None) {
 			Ok(store) => store,
 			Err(e) => {
 				error!("Failed to create SqliteStore: {e:?}");
 				std::process::exit(-1);
 			},
-		});
+		},
+	);
 
 	#[cfg(not(feature = "events-rabbitmq"))]
 	let event_publisher: Arc<dyn EventPublisher> =
@@ -213,6 +215,20 @@ fn main() {
 		let rest_svc_listener = TcpListener::bind(config_file.rest_service_addr)
 			.await
 			.expect("Failed to bind listening port");
+
+		let server_config = match get_or_generate_tls_config(
+			config_file.tls_config,
+			&config_file.storage_dir_path,
+		) {
+			Ok(config) => config,
+			Err(e) => {
+				error!("Failed to set up TLS: {e}");
+				std::process::exit(-1);
+			}
+		};
+		let tls_acceptor = tokio_rustls::TlsAcceptor::from(Arc::new(server_config));
+		info!("TLS enabled for REST service on {}", config_file.rest_service_addr);
+
 		loop {
 			select! {
 				event = event_node.next_event_async() => {
@@ -355,11 +371,17 @@ fn main() {
 				res = rest_svc_listener.accept() => {
 					match res {
 						Ok((stream, _)) => {
-							let io_stream = TokioIo::new(stream);
 							let node_service = NodeService::new(Arc::clone(&node), Arc::clone(&paginated_store), config_file.api_key.clone());
+							let acceptor = tls_acceptor.clone();
 							runtime.spawn(async move {
-								if let Err(err) = http1::Builder::new().serve_connection(io_stream, node_service).await {
-									error!("Failed to serve connection: {}", err);
+								match acceptor.accept(stream).await {
+									Ok(tls_stream) => {
+										let io_stream = TokioIo::new(tls_stream);
+										if let Err(err) = http1::Builder::new().serve_connection(io_stream, node_service).await {
+											error!("Failed to serve TLS connection: {err}");
+										}
+									},
+									Err(e) => error!("TLS handshake failed: {e}"),
 								}
 							});
 						},

--- a/ldk-server/src/util/mod.rs
+++ b/ldk-server/src/util/mod.rs
@@ -10,3 +10,4 @@
 pub(crate) mod config;
 pub(crate) mod logger;
 pub(crate) mod proto_adapter;
+pub(crate) mod tls;

--- a/ldk-server/src/util/tls.rs
+++ b/ldk-server/src/util/tls.rs
@@ -1,0 +1,226 @@
+// This file is Copyright its original authors, visible in version control
+// history.
+//
+// This file is licensed under the Apache License, Version 2.0 <LICENSE-APACHE
+// or http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your option.
+// You may not use this file except in accordance with one or both of these
+// licenses.
+
+use crate::util::config::TlsConfig;
+use base64::Engine;
+use rcgen::{generate_simple_self_signed, CertifiedKey};
+use std::fs;
+use tokio_rustls::rustls::pki_types::{CertificateDer, PrivateKeyDer};
+use tokio_rustls::rustls::ServerConfig;
+
+// PEM markers
+const PEM_CERT_BEGIN: &str = "-----BEGIN CERTIFICATE-----";
+const PEM_CERT_END: &str = "-----END CERTIFICATE-----";
+const PEM_KEY_BEGIN: &str = "-----BEGIN PRIVATE KEY-----";
+const PEM_KEY_END: &str = "-----END PRIVATE KEY-----";
+
+/// Gets or generates TLS configuration. If custom paths are provided, uses those.
+/// Otherwise, generates a self-signed certificate in the storage directory.
+pub fn get_or_generate_tls_config(
+	tls_config: Option<TlsConfig>, storage_dir: &str,
+) -> Result<ServerConfig, String> {
+	if let Some(config) = tls_config {
+		let cert_path = config.cert_path.unwrap_or(format!("{storage_dir}/tls.crt"));
+		let key_path = config.key_path.unwrap_or(format!("{storage_dir}/tls.key"));
+		if !fs::exists(&cert_path).unwrap_or(false) || !fs::exists(&key_path).unwrap_or(false) {
+			generate_self_signed_cert(&cert_path, &key_path, &config.hosts)?;
+		}
+		load_tls_config(&cert_path, &key_path)
+	} else {
+		// Check if we already have generated certs, if we don't, generate new ones
+		let cert_path = format!("{storage_dir}/tls.crt");
+		let key_path = format!("{storage_dir}/tls.key");
+		if !fs::exists(&cert_path).unwrap_or(false) || !fs::exists(&key_path).unwrap_or(false) {
+			generate_self_signed_cert(&cert_path, &key_path, &[])?;
+		}
+
+		load_tls_config(&cert_path, &key_path)
+	}
+}
+
+/// Parses a PEM-encoded certificate file and returns the DER-encoded certificates.
+fn parse_pem_certs(pem_data: &str) -> Result<Vec<CertificateDer<'static>>, String> {
+	let mut certs = Vec::new();
+
+	for block in pem_data.split(PEM_CERT_END) {
+		if let Some(start) = block.find(PEM_CERT_BEGIN) {
+			let base64_content: String = block[start + PEM_CERT_BEGIN.len()..]
+				.lines()
+				.filter(|line| !line.starts_with("-----") && !line.is_empty())
+				.collect();
+
+			let der = base64::engine::general_purpose::STANDARD
+				.decode(&base64_content)
+				.map_err(|e| format!("Failed to decode certificate base64: {e}"))?;
+
+			certs.push(CertificateDer::from(der));
+		}
+	}
+
+	Ok(certs)
+}
+
+/// Parses a PEM-encoded PKCS#8 private key file and returns the DER-encoded key.
+fn parse_pem_private_key(pem_data: &str) -> Result<PrivateKeyDer<'static>, String> {
+	let start = pem_data.find(PEM_KEY_BEGIN).ok_or("Missing BEGIN PRIVATE KEY marker")?;
+	let end = pem_data.find(PEM_KEY_END).ok_or("Missing END PRIVATE KEY marker")?;
+
+	let base64_content: String = pem_data[start + PEM_KEY_BEGIN.len()..end]
+		.lines()
+		.filter(|line| !line.starts_with("-----") && !line.is_empty())
+		.collect();
+
+	let der = base64::engine::general_purpose::STANDARD
+		.decode(&base64_content)
+		.map_err(|e| format!("Failed to decode private key base64: {e}"))?;
+
+	Ok(PrivateKeyDer::Pkcs8(der.into()))
+}
+
+/// Generates a self-signed TLS certificate and saves it to the storage directory.
+/// Returns the paths to the generated cert and key files.
+fn generate_self_signed_cert(
+	cert_path: &str, key_path: &str, configure_hosts: &[String],
+) -> Result<(), String> {
+	let mut hosts = vec!["localhost".to_string(), "127.0.0.1".to_string()];
+	hosts.extend_from_slice(configure_hosts);
+
+	let CertifiedKey { cert, key_pair } = generate_simple_self_signed(hosts)
+		.map_err(|e| format!("Failed to generate self-signed certificate: {e}"))?;
+
+	// Convert DER to PEM format
+	let cert_der = cert.der();
+	let key_der = key_pair.serialize_der();
+
+	let cert_pem = format!(
+		"{PEM_CERT_BEGIN}\n{}\n{PEM_CERT_END}\n",
+		base64::engine::general_purpose::STANDARD
+			.encode(cert_der)
+			.as_bytes()
+			.chunks(64)
+			.map(|chunk| std::str::from_utf8(chunk).unwrap())
+			.collect::<Vec<_>>()
+			.join("\n")
+	);
+
+	let key_pem = format!(
+		"{PEM_KEY_BEGIN}\n{}\n{PEM_KEY_END}\n",
+		base64::engine::general_purpose::STANDARD
+			.encode(&key_der)
+			.as_bytes()
+			.chunks(64)
+			.map(|chunk| std::str::from_utf8(chunk).unwrap())
+			.collect::<Vec<_>>()
+			.join("\n")
+	);
+
+	fs::write(cert_path, &cert_pem)
+		.map_err(|e| format!("Failed to write TLS certificate to '{cert_path}': {e}"))?;
+	fs::write(key_path, &key_pem)
+		.map_err(|e| format!("Failed to write TLS key to '{key_path}': {e}"))?;
+
+	Ok(())
+}
+
+/// Loads TLS configuration from provided paths.
+fn load_tls_config(cert_path: &str, key_path: &str) -> Result<ServerConfig, String> {
+	let cert_pem = fs::read_to_string(cert_path)
+		.map_err(|e| format!("Failed to read TLS certificate file '{cert_path}': {e}"))?;
+	let key_pem = fs::read_to_string(key_path)
+		.map_err(|e| format!("Failed to read TLS key file '{key_path}': {e}"))?;
+
+	let certs = parse_pem_certs(&cert_pem)?;
+
+	if certs.is_empty() {
+		return Err("No certificates found in certificate file".to_string());
+	}
+
+	let key = parse_pem_private_key(&key_pem)?;
+
+	ServerConfig::builder()
+		.with_no_client_auth()
+		.with_single_cert(certs, key)
+		.map_err(|e| format!("Failed to build TLS server config: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn test_parse_pem_certs() {
+		let pem = "-----BEGIN CERTIFICATE-----\nMIIBkTCB+wIJAKHBfpegPjMCMA0GCSqGSIb3DQEBCwUAMBExDzANBgNVBAMMBnVu\ndXNlZDAeFw0yMzAxMDEwMDAwMDBaFw0yNDAxMDEwMDAwMDBaMBExDzANBgNVBAMM\nBnVudXNlZDBcMA0GCSqGSIb3DQEBAQUAA0sAMEgCQQC7o96FCEcJsggt0c0dSfEB\nmm6vv1LdCoxXnhOSCutoJgJgmCPBjU1doFFKwAtXjfOv0eSLZ3NHLu0LRKmVvOsP\nAgMBAAGjUzBRMB0GA1UdDgQWBBQK3fc0myO0psd71FJd8v7VCmDJOzAfBgNVHSME\nGDAWgBQK3fc0myO0psd71FJd8v7VCmDJOzAPBgNVHRMBAf8EBTADAQH/MA0GCSqG\nSIb3DQEBCwUAA0EAhJg0cx2pFfVfGBfbJQNFa+A4ynJBMqKYlbUnJBfWPwg13RhC\nivLjYyhKzEbnOug0TuFfVaUBGfBYbPgaJQ4BAg==\n-----END CERTIFICATE-----\n";
+
+		let certs = parse_pem_certs(pem).unwrap();
+		assert_eq!(certs.len(), 1);
+		assert!(!certs[0].is_empty());
+	}
+
+	#[test]
+	fn test_parse_pem_certs_multiple() {
+		let pem = "-----BEGIN CERTIFICATE-----\nMIIBkTCB+wIJAKHBfpegPjMCMA0GCSqGSIb3DQEBCwUAMBExDzANBgNVBAMMBnVu\ndXNlZDAeFw0yMzAxMDEwMDAwMDBaFw0yNDAxMDEwMDAwMDBaMBExDzANBgNVBAMM\nBnVudXNlZDBcMA0GCSqGSIb3DQEBAQUAA0sAMEgCQQC7o96FCEcJsggt0c0dSfEB\nmm6vv1LdCoxXnhOSCutoJgJgmCPBjU1doFFKwAtXjfOv0eSLZ3NHLu0LRKmVvOsP\nAgMBAAGjUzBRMB0GA1UdDgQWBBQK3fc0myO0psd71FJd8v7VCmDJOzAfBgNVHSME\nGDAWgBQK3fc0myO0psd71FJd8v7VCmDJOzAPBgNVHRMBAf8EBTADAQH/MA0GCSqG\nSIb3DQEBCwUAA0EAhJg0cx2pFfVfGBfbJQNFa+A4ynJBMqKYlbUnJBfWPwg13RhC\nivLjYyhKzEbnOug0TuFfVaUBGfBYbPgaJQ4BAg==\n-----END CERTIFICATE-----\n-----BEGIN CERTIFICATE-----\nMIIBkTCB+wIJAKHBfpegPjMCMA0GCSqGSIb3DQEBCwUAMBExDzANBgNVBAMMBnVu\ndXNlZDAeFw0yMzAxMDEwMDAwMDBaFw0yNDAxMDEwMDAwMDBaMBExDzANBgNVBAMM\nBnVudXNlZDBcMA0GCSqGSIb3DQEBAQUAA0sAMEgCQQC7o96FCEcJsggt0c0dSfEB\nmm6vv1LdCoxXnhOSCutoJgJgmCPBjU1doFFKwAtXjfOv0eSLZ3NHLu0LRKmVvOsP\nAgMBAAGjUzBRMB0GA1UdDgQWBBQK3fc0myO0psd71FJd8v7VCmDJOzAfBgNVHSME\nGDAWgBQK3fc0myO0psd71FJd8v7VCmDJOzAPBgNVHRMBAf8EBTADAQH/MA0GCSqG\nSIb3DQEBCwUAA0EAhJg0cx2pFfVfGBfbJQNFa+A4ynJBMqKYlbUnJBfWPwg13RhC\nivLjYyhKzEbnOug0TuFfVaUBGfBYbPgaJQ4BAg==\n-----END CERTIFICATE-----\n";
+
+		let certs = parse_pem_certs(pem).unwrap();
+		assert_eq!(certs.len(), 2);
+	}
+
+	#[test]
+	fn test_parse_pem_certs_empty() {
+		let certs = parse_pem_certs("").unwrap();
+		assert!(certs.is_empty());
+
+		let certs = parse_pem_certs("not a cert").unwrap();
+		assert!(certs.is_empty());
+	}
+
+	#[test]
+	fn test_parse_pem_private_key_pkcs8() {
+		let pem = "-----BEGIN PRIVATE KEY-----\nMIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQg2a2rwplBQLzHPDvn\nsaw8HKDP6WYBSF684gcz+D7zeVShRANCAAQq8R/E45tTNWMEpK8abYM7VzuJxpPS\nhJCi6bzjOPGHawEO8safLOWFaV7GqLJM0OdM3eu/qcz8HwgI3T8EVHQK\n-----END PRIVATE KEY-----\n";
+
+		let key = parse_pem_private_key(pem).unwrap();
+		assert!(matches!(key, PrivateKeyDer::Pkcs8(_)));
+	}
+
+	#[test]
+	fn test_parse_pem_private_key_invalid() {
+		let result = parse_pem_private_key("");
+		assert!(result.is_err());
+
+		let result = parse_pem_private_key("not a key");
+		assert!(result.is_err());
+	}
+
+	#[test]
+	fn test_generate_and_load_roundtrip() {
+		let temp_dir = std::env::temp_dir();
+		let suffix: u64 = rand::random();
+		let cert_path = temp_dir.join(format!("test_tls_cert_{suffix}.pem"));
+		let key_path = temp_dir.join(format!("test_tls_key_{suffix}.pem"));
+
+		// Clean up any existing files to be safe
+		let _ = fs::remove_file(&cert_path);
+		let _ = fs::remove_file(&key_path);
+
+		// Generate cert
+		generate_self_signed_cert(cert_path.to_str().unwrap(), key_path.to_str().unwrap(), &[])
+			.unwrap();
+
+		// Verify files exist
+		assert!(cert_path.exists());
+		assert!(key_path.exists());
+
+		// Load config
+		let res = load_tls_config(cert_path.to_str().unwrap(), key_path.to_str().unwrap());
+		assert!(res.is_ok());
+
+		// Clean up
+		let _ = fs::remove_file(&cert_path);
+		let _ = fs::remove_file(&key_path);
+	}
+}


### PR DESCRIPTION
Built on top of #88 to reduce conflicts

With TLS we can now have encrypted communication with the client and
server. We auto generate a self signed cert on startup.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>