### PR TITLE
Add node `alias` to config file

### DIFF
--- a/ldk-server/ldk-server-config.toml
+++ b/ldk-server/ldk-server-config.toml
@@ -4,6 +4,7 @@ network = "regtest"                           # Bitcoin network to use
 listening_addresses = ["localhost:3001"]      # Lightning node listening addresses
 announcement_addresses = ["54.3.7.81:3001"]   # Lightning node announcement addresses
 rest_service_address = "127.0.0.1:3002"       # LDK Server REST address
+alias = "ldk_server"                          # Lightning node alias
 
 # Storage settings
 [storage.disk]


### PR DESCRIPTION
Now that we added `announcement_addresses` to `Config`/config file, attempting to start the server without configuring a node alias results in a build error.