### PR TITLE
Add serde serializers for Bytes and Enums in protos

### DIFF
--- a/ldk-server-protos/build.rs
+++ b/ldk-server-protos/build.rs
@@ -41,6 +41,30 @@ fn generate_protos() {
 			"#[cfg_attr(feature = \"serde\", derive(serde::Serialize, serde::Deserialize))]",
 		)
 		.type_attribute(".", "#[cfg_attr(feature = \"serde\", serde(rename_all = \"snake_case\"))]")
+		.field_attribute(
+			"types.Bolt11.secret",
+			"#[cfg_attr(feature = \"serde\", serde(serialize_with = \"crate::serde_utils::serialize_opt_bytes_hex\"))]",
+		)
+		.field_attribute(
+			"types.Bolt11Jit.secret",
+			"#[cfg_attr(feature = \"serde\", serde(serialize_with = \"crate::serde_utils::serialize_opt_bytes_hex\"))]",
+		)
+		.field_attribute(
+			"types.Bolt12Offer.secret",
+			"#[cfg_attr(feature = \"serde\", serde(serialize_with = \"crate::serde_utils::serialize_opt_bytes_hex\"))]",
+		)
+		.field_attribute(
+			"types.Bolt12Refund.secret",
+			"#[cfg_attr(feature = \"serde\", serde(serialize_with = \"crate::serde_utils::serialize_opt_bytes_hex\"))]",
+		)
+		.field_attribute(
+			"types.Payment.direction",
+			"#[cfg_attr(feature = \"serde\", serde(serialize_with = \"crate::serde_utils::serialize_payment_direction\"))]",
+		)
+		.field_attribute(
+			"types.Payment.status",
+			"#[cfg_attr(feature = \"serde\", serde(serialize_with = \"crate::serde_utils::serialize_payment_status\"))]",
+		)
 		.compile_protos(
 			&[
 				"src/proto/api.proto",

--- a/ldk-server-protos/src/lib.rs
+++ b/ldk-server-protos/src/lib.rs
@@ -11,4 +11,6 @@ pub mod api;
 pub mod endpoints;
 pub mod error;
 pub mod events;
+#[cfg(feature = "serde")]
+pub mod serde_utils;
 pub mod types;

--- a/ldk-server-protos/src/serde_utils.rs
+++ b/ldk-server-protos/src/serde_utils.rs
@@ -1,0 +1,57 @@
+// This file is Copyright its original authors, visible in version control
+// history.
+//
+// This file is licensed under the Apache License, Version 2.0 <LICENSE-APACHE
+// or http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your option.
+// You may not use this file except in accordance with one or both of these
+// licenses.
+
+//! Custom serde serializers for proto types.
+//!
+//! These are used via `#[serde(serialize_with = "...")]` attributes on generated
+//! proto fields to produce human-readable output (hex strings for bytes, enum
+//! names for integer enum fields).
+
+use std::fmt::Write;
+
+use serde::Serializer;
+
+/// Generates a serde serializer that converts an `i32` proto enum field to its
+/// string name via `from_i32()` and `as_str_name()`.
+macro_rules! stringify_enum_serializer {
+	($fn_name:ident, $enum_type:ty) => {
+		pub fn $fn_name<S>(value: &i32, serializer: S) -> Result<S::Ok, S::Error>
+		where
+			S: serde::Serializer,
+		{
+			let name = match <$enum_type>::from_i32(*value) {
+				Some(v) => v.as_str_name(),
+				None => "UNKNOWN",
+			};
+			serializer.serialize_str(name)
+		}
+	};
+}
+
+stringify_enum_serializer!(serialize_payment_direction, crate::types::PaymentDirection);
+stringify_enum_serializer!(serialize_payment_status, crate::types::PaymentStatus);
+
+/// Serializes `Option<prost::bytes::Bytes>` as a hex string (or null).
+pub fn serialize_opt_bytes_hex<S>(
+	value: &Option<bytes::Bytes>, serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+	S: Serializer,
+{
+	match value {
+		Some(bytes) => {
+			let hex = bytes.iter().fold(String::with_capacity(bytes.len() * 2), |mut acc, b| {
+				let _ = write!(acc, "{b:02x}");
+				acc
+			});
+			serializer.serialize_some(&hex)
+		},
+		None => serializer.serialize_none(),
+	}
+}

--- a/ldk-server-protos/src/types.rs
+++ b/ldk-server-protos/src/types.rs
@@ -31,9 +31,17 @@ pub struct Payment {
 	pub fee_paid_msat: ::core::option::Option<u64>,
 	/// The direction of the payment.
 	#[prost(enumeration = "PaymentDirection", tag = "4")]
+	#[cfg_attr(
+		feature = "serde",
+		serde(serialize_with = "crate::serde_utils::serialize_payment_direction")
+	)]
 	pub direction: i32,
 	/// The status of the payment.
 	#[prost(enumeration = "PaymentStatus", tag = "5")]
+	#[cfg_attr(
+		feature = "serde",
+		serde(serialize_with = "crate::serde_utils::serialize_payment_status")
+	)]
 	pub status: i32,
 	/// The timestamp, in seconds since start of the UNIX epoch, when this entry was last updated.
 	#[prost(uint64, tag = "6")]
@@ -138,6 +146,10 @@ pub struct Bolt11 {
 	pub preimage: ::core::option::Option<::prost::alloc::string::String>,
 	/// The secret used by the payment.
 	#[prost(bytes = "bytes", optional, tag = "3")]
+	#[cfg_attr(
+		feature = "serde",
+		serde(serialize_with = "crate::serde_utils::serialize_opt_bytes_hex")
+	)]
 	pub secret: ::core::option::Option<::prost::bytes::Bytes>,
 }
 /// Represents a BOLT 11 payment intended to open an LSPS 2 just-in-time channel.
@@ -154,6 +166,10 @@ pub struct Bolt11Jit {
 	pub preimage: ::core::option::Option<::prost::alloc::string::String>,
 	/// The secret used by the payment.
 	#[prost(bytes = "bytes", optional, tag = "3")]
+	#[cfg_attr(
+		feature = "serde",
+		serde(serialize_with = "crate::serde_utils::serialize_opt_bytes_hex")
+	)]
 	pub secret: ::core::option::Option<::prost::bytes::Bytes>,
 	/// Limits applying to how much fee we allow an LSP to deduct from the payment amount.
 	///
@@ -184,6 +200,10 @@ pub struct Bolt12Offer {
 	pub preimage: ::core::option::Option<::prost::alloc::string::String>,
 	/// The secret used by the payment.
 	#[prost(bytes = "bytes", optional, tag = "3")]
+	#[cfg_attr(
+		feature = "serde",
+		serde(serialize_with = "crate::serde_utils::serialize_opt_bytes_hex")
+	)]
 	pub secret: ::core::option::Option<::prost::bytes::Bytes>,
 	/// The hex-encoded ID of the offer this payment is for.
 	#[prost(string, tag = "4")]
@@ -213,6 +233,10 @@ pub struct Bolt12Refund {
 	pub preimage: ::core::option::Option<::prost::alloc::string::String>,
 	/// The secret used by the payment.
 	#[prost(bytes = "bytes", optional, tag = "3")]
+	#[cfg_attr(
+		feature = "serde",
+		serde(serialize_with = "crate::serde_utils::serialize_opt_bytes_hex")
+	)]
 	pub secret: ::core::option::Option<::prost::bytes::Bytes>,
 	/// The payer's note for the payment.
 	/// Truncated to \[PAYER_NOTE_LIMIT\](<https://docs.rs/lightning/latest/lightning/offers/invoice_request/constant.PAYER_NOTE_LIMIT.html>).


### PR DESCRIPTION
Adds serializers for bytevectors and enums defined in our proto files.
This makes it so we can print out something like `"status": "SUCCEEDED"` instead of `"status": 1`.

before:

```
₿ ldk-server-cli list-payments 
{
  "payments": [
    {
      "id": "0bfd4050d9251e9c8dc14d4f59e579a47db055f649ad093ac9f463b38fc63daf",
      "kind": {
        "kind": {
          "bolt11": {
            "hash": "0bfd4050d9251e9c8dc14d4f59e579a47db055f649ad093ac9f463b38fc63daf",
            "preimage": "69172b32ae823751d37c7485c17ebb168f165b900435370dc267e6f71e381a66",
            "secret": [
              93,
              160,
              246,
              39,
              147,
              33,
              180,
              246,
              98,
              129,
              85,
              25,
              203,
              68,
              48,
              58,
              251,
              79,
              201,
              51,
              119,
              173,
              62,
              224,
              182,
              102,
              92,
              126,
              221,
              2,
              198,
              163
            ]
          }
        }
      },
      "amount_msat": 1000000000,
      "fee_paid_msat": 0,
      "direction": 1,
      "status": 1,
      "latest_update_timestamp": 1770412903
    }
  ]
}
```

after:

```
₿ ldk-server-cli list-payments 
{
  "list": [
    {
      "id": "0bfd4050d9251e9c8dc14d4f59e579a47db055f649ad093ac9f463b38fc63daf",
      "kind": {
        "kind": {
          "bolt11": {
            "hash": "0bfd4050d9251e9c8dc14d4f59e579a47db055f649ad093ac9f463b38fc63daf",
            "preimage": "69172b32ae823751d37c7485c17ebb168f165b900435370dc267e6f71e381a66",
            "secret": "5da0f6279321b4f662815519cb44303afb4fc93377ad3ee0b6665c7edd02c6a3"
          }
        }
      },
      "amount_msat": 1000000000,
      "fee_paid_msat": 0,
      "direction": "OUTBOUND",
      "status": "SUCCEEDED",
      "latest_update_timestamp": 1770412903
    }
  ]
}
```