### PR TITLE
Add Rapid Gossip Sync support

### DIFF
--- a/ldk-server/ldk-server-config.toml
+++ b/ldk-server/ldk-server-config.toml
@@ -6,6 +6,7 @@ announcement_addresses = ["54.3.7.81:3001"]   # Lightning node announcement addr
 rest_service_address = "127.0.0.1:3002"       # LDK Server REST address
 alias = "ldk_server"                          # Lightning node alias
 #pathfinding_scores_source_url = ""           # External Pathfinding Scores Source
+#rgs_server_url = "https://rapidsync.lightningdevkit.org/snapshot/v2/"  # Optional: RGS URL for rapid gossip sync
 
 # Storage settings
 [storage.disk]

--- a/ldk-server/src/main.rs
+++ b/ldk-server/src/main.rs
@@ -167,6 +167,10 @@ fn main() {
 		builder.set_pathfinding_scores_source(pathfinding_scores_source);
 	}
 
+	if let Some(rgs_server_url) = config_file.rgs_server_url {
+		builder.set_gossip_source_rgs(rgs_server_url);
+	}
+
 	// LSPS2 support is highly experimental and for testing purposes only.
 	#[cfg(feature = "experimental-lsps2-support")]
 	builder.set_liquidity_provider_lsps2(

--- a/ldk-server/src/util/config.rs
+++ b/ldk-server/src/util/config.rs
@@ -46,6 +46,7 @@ pub struct Config {
 	pub rest_service_addr: SocketAddr,
 	pub storage_dir_path: Option<String>,
 	pub chain_source: ChainSource,
+	pub rgs_server_url: Option<String>,
 	pub rabbitmq_connection_string: String,
 	pub rabbitmq_exchange_name: String,
 	pub lsps2_service_config: Option<LSPS2ServiceConfig>,
@@ -83,6 +84,7 @@ struct ConfigBuilder {
 	bitcoind_rpc_address: Option<String>,
 	bitcoind_rpc_user: Option<String>,
 	bitcoind_rpc_password: Option<String>,
+	rgs_server_url: Option<String>,
 	rabbitmq_connection_string: Option<String>,
 	rabbitmq_exchange_name: Option<String>,
 	lsps2: Option<LiquidityConfig>,
@@ -104,6 +106,7 @@ impl ConfigBuilder {
 			self.alias = node.alias.or(self.alias.clone());
 			self.pathfinding_scores_source_url =
 				node.pathfinding_scores_source_url.or(self.pathfinding_scores_source_url.clone());
+			self.rgs_server_url = node.rgs_server_url.or(self.rgs_server_url.clone());
 		}
 
 		if let Some(storage) = toml.storage {
@@ -349,6 +352,7 @@ impl ConfigBuilder {
 			rest_service_addr,
 			storage_dir_path: self.storage_dir_path,
 			chain_source,
+			rgs_server_url: self.rgs_server_url,
 			rabbitmq_connection_string,
 			rabbitmq_exchange_name,
 			lsps2_service_config,
@@ -381,6 +385,7 @@ struct NodeConfig {
 	rest_service_address: Option<String>,
 	alias: Option<String>,
 	pathfinding_scores_source_url: Option<String>,
+	rgs_server_url: Option<String>,
 }
 
 #[derive(Deserialize, Serialize)]
@@ -637,6 +642,7 @@ mod tests {
 				announcement_addresses = ["54.3.7.81:3001"]
 				rest_service_address = "127.0.0.1:3002"
 				alias = "LDK Server"
+				rgs_server_url = "https://rapidsync.lightningdevkit.org/snapshot/v2/"
 
 				[tls]
 				cert_path = "/path/to/tls.crt"
@@ -750,6 +756,7 @@ mod tests {
 				rpc_user: "bitcoind-testuser".to_string(),
 				rpc_password: "bitcoind-testpassword".to_string(),
 			},
+			rgs_server_url: Some("https://rapidsync.lightningdevkit.org/snapshot/v2/".to_string()),
 			rabbitmq_connection_string: expected_rabbit_conn,
 			rabbitmq_exchange_name: expected_rabbit_exchange,
 			lsps2_service_config: Some(LSPS2ServiceConfig {
@@ -776,6 +783,7 @@ mod tests {
 		assert_eq!(config.rest_service_addr, expected.rest_service_addr);
 		assert_eq!(config.storage_dir_path, expected.storage_dir_path);
 		assert_eq!(config.chain_source, expected.chain_source);
+		assert_eq!(config.rgs_server_url, expected.rgs_server_url);
 		assert_eq!(config.rabbitmq_connection_string, expected.rabbitmq_connection_string);
 		assert_eq!(config.rabbitmq_exchange_name, expected.rabbitmq_exchange_name);
 		#[cfg(feature = "experimental-lsps2-support")]
@@ -1069,6 +1077,7 @@ mod tests {
 				rpc_user: args_config.bitcoind_rpc_user.unwrap(),
 				rpc_password: args_config.bitcoind_rpc_password.unwrap(),
 			},
+			rgs_server_url: None,
 			rabbitmq_connection_string: String::new(),
 			rabbitmq_exchange_name: String::new(),
 			lsps2_service_config: None,
@@ -1083,6 +1092,7 @@ mod tests {
 		assert_eq!(config.rest_service_addr, expected.rest_service_addr);
 		assert_eq!(config.storage_dir_path, expected.storage_dir_path);
 		assert_eq!(config.chain_source, expected.chain_source);
+		assert_eq!(config.rgs_server_url, expected.rgs_server_url);
 		assert_eq!(config.rabbitmq_connection_string, expected.rabbitmq_connection_string);
 		assert_eq!(config.rabbitmq_exchange_name, expected.rabbitmq_exchange_name);
 		assert!(config.lsps2_service_config.is_none());
@@ -1160,6 +1170,7 @@ mod tests {
 				rpc_user: args_config.bitcoind_rpc_user.unwrap(),
 				rpc_password: args_config.bitcoind_rpc_password.unwrap(),
 			},
+			rgs_server_url: Some("https://rapidsync.lightningdevkit.org/snapshot/v2/".to_string()),
 			rabbitmq_connection_string: expected_rabbit_conn,
 			rabbitmq_exchange_name: expected_rabbit_exchange,
 			lsps2_service_config: Some(LSPS2ServiceConfig {
@@ -1185,6 +1196,7 @@ mod tests {
 		assert_eq!(config.rest_service_addr, expected.rest_service_addr);
 		assert_eq!(config.storage_dir_path, expected.storage_dir_path);
 		assert_eq!(config.chain_source, expected.chain_source);
+		assert_eq!(config.rgs_server_url, expected.rgs_server_url);
 		assert_eq!(config.rabbitmq_connection_string, expected.rabbitmq_connection_string);
 		assert_eq!(config.rabbitmq_exchange_name, expected.rabbitmq_exchange_name);
 		#[cfg(feature = "experimental-lsps2-support")]


### PR DESCRIPTION
Allow configuring an RGS server URL. When set, the node uses RGS instead of P2P gossip. This can be faster than syncing the entire network graph and can reduce bandwidth usage. 


Needed this when starting a new node and gossip synced slowly. Also added the `list_peers` cli that I used while debugging.