### PR TITLE
Add systemd readiness and stopping notifications

### DIFF
--- a/ldk-server/src/main.rs
+++ b/ldk-server/src/main.rs
@@ -51,6 +51,7 @@ use crate::service::NodeService;
 use crate::util::config::{load_config, ArgsConfig, ChainSource};
 use crate::util::logger::ServerLogger;
 use crate::util::proto_adapter::{forwarded_payment_to_proto, payment_to_proto};
+use crate::util::systemd;
 use crate::util::tls::get_or_generate_tls_config;
 
 const API_KEY_FILE: &str = "api_key";
@@ -273,6 +274,8 @@ fn main() {
 		let tls_acceptor = tokio_rustls::TlsAcceptor::from(Arc::new(server_config));
 		info!("TLS enabled for REST service on {}", config_file.rest_service_addr);
 
+		systemd::notify_ready();
+
 		loop {
 			select! {
 				event = event_node.next_event_async() => {
@@ -449,6 +452,7 @@ fn main() {
 		}
 	});
 
+	systemd::notify_stopping();
 	node.stop().expect("Shutdown should always succeed.");
 	info!("Shutdown complete..");
 }

--- a/ldk-server/src/util/mod.rs
+++ b/ldk-server/src/util/mod.rs
@@ -10,4 +10,5 @@
 pub(crate) mod config;
 pub(crate) mod logger;
 pub(crate) mod proto_adapter;
+pub(crate) mod systemd;
 pub(crate) mod tls;

--- a/ldk-server/src/util/systemd.rs
+++ b/ldk-server/src/util/systemd.rs
@@ -1,0 +1,68 @@
+// This file is Copyright its original authors, visible in version control
+// history.
+//
+// This file is licensed under the Apache License, Version 2.0 <LICENSE-APACHE
+// or http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your option.
+// You may not use this file except in accordance with one or both of these
+// licenses.
+
+#[cfg(target_os = "linux")]
+use std::os::linux::net::SocketAddrExt;
+#[cfg(target_os = "linux")]
+use std::os::unix::net::UnixDatagram;
+
+#[cfg(target_os = "linux")]
+use log::{info, warn};
+
+#[cfg(target_os = "linux")]
+fn notify(state: &str) {
+	let socket_path = match std::env::var("NOTIFY_SOCKET") {
+		Ok(path) => path,
+		Err(_) => return,
+	};
+
+	let socket = match UnixDatagram::unbound() {
+		Ok(s) => s,
+		Err(e) => {
+			warn!("Failed to create socket for systemd notification: {e}");
+			return;
+		},
+	};
+
+	// systemd sets NOTIFY_SOCKET to either a filesystem path (e.g. /run/systemd/notify)
+	// or an abstract socket prefixed with '@'. Abstract sockets require special addressing.
+	let result = if let Some(abstract_name) = socket_path.strip_prefix('@') {
+		match std::os::unix::net::SocketAddr::from_abstract_name(abstract_name) {
+			Ok(addr) => socket.send_to_addr(state.as_bytes(), &addr),
+			Err(e) => {
+				warn!("Failed to create abstract socket address: {e}");
+				return;
+			},
+		}
+	} else {
+		socket.send_to(state.as_bytes(), &socket_path)
+	};
+
+	if let Err(e) = result {
+		warn!("Failed to send systemd notification: {e}");
+	} else {
+		info!("Sent systemd notification: {state}");
+	}
+}
+
+#[cfg(target_os = "linux")]
+pub fn notify_ready() {
+	notify("READY=1");
+}
+
+#[cfg(target_os = "linux")]
+pub fn notify_stopping() {
+	notify("STOPPING=1");
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn notify_ready() {}
+
+#[cfg(not(target_os = "linux"))]
+pub fn notify_stopping() {}


### PR DESCRIPTION
If NOTIFY_SOCKET is set, send READY=1 and STOPPING=1 to systemd. This enables proper dependency ordering and faster startup detection when running as a Type=notify service unit.

Noticed this when deploying my own mainnet ldk-server on my server