### PR TITLE
Add ListPeers RPC

### DIFF
--- a/e2e-tests/tests/e2e.rs
+++ b/e2e-tests/tests/e2e.rs
@@ -182,6 +182,29 @@ async fn test_cli_connect_peer() {
 	assert!(output.is_object());
 }
 
+#[tokio::test]
+async fn test_cli_list_peers() {
+	let bitcoind = TestBitcoind::new();
+	let server_a = LdkServerHandle::start(&bitcoind).await;
+	let server_b = LdkServerHandle::start(&bitcoind).await;
+
+	let output = run_cli(&server_a, &["list-peers"]);
+	assert!(output["peers"].as_array().unwrap().is_empty());
+	let output = run_cli(&server_b, &["list-peers"]);
+	assert!(output["peers"].as_array().unwrap().is_empty());
+
+	let addr = format!("127.0.0.1:{}", server_b.p2p_port);
+	run_cli(&server_a, &["connect-peer", server_b.node_id(), &addr]);
+
+	let output = run_cli(&server_a, &["list-peers"]);
+	let peers = output["peers"].as_array().unwrap();
+	assert_eq!(peers.len(), 1);
+	assert_eq!(peers[0]["node_id"], server_b.node_id());
+	assert_eq!(peers[0]["address"], addr);
+	assert_eq!(peers[0]["is_persisted"], false);
+	assert_eq!(peers[0]["is_connected"], true);
+}
+
 // === CLI tests: Group 4 — Two-node with channel ===
 
 #[tokio::test]

--- a/ldk-server-cli/src/main.rs
+++ b/ldk-server-cli/src/main.rs
@@ -31,10 +31,10 @@ use ldk_server_client::ldk_server_protos::api::{
 	GraphGetChannelRequest, GraphGetChannelResponse, GraphGetNodeRequest, GraphGetNodeResponse,
 	GraphListChannelsRequest, GraphListChannelsResponse, GraphListNodesRequest,
 	GraphListNodesResponse, ListChannelsRequest, ListChannelsResponse,
-	ListForwardedPaymentsRequest, ListPaymentsRequest, OnchainReceiveRequest,
-	OnchainReceiveResponse, OnchainSendRequest, OnchainSendResponse, OpenChannelRequest,
-	OpenChannelResponse, SignMessageRequest, SignMessageResponse, SpliceInRequest,
-	SpliceInResponse, SpliceOutRequest, SpliceOutResponse, SpontaneousSendRequest,
+	ListForwardedPaymentsRequest, ListPaymentsRequest, ListPeersRequest, ListPeersResponse,
+	OnchainReceiveRequest, OnchainReceiveResponse, OnchainSendRequest, OnchainSendResponse,
+	OpenChannelRequest, OpenChannelResponse, SignMessageRequest, SignMessageResponse,
+	SpliceInRequest, SpliceInResponse, SpliceOutRequest, SpliceOutResponse, SpontaneousSendRequest,
 	SpontaneousSendResponse, UpdateChannelConfigRequest, UpdateChannelConfigResponse,
 	VerifySignatureRequest, VerifySignatureResponse,
 };
@@ -385,6 +385,8 @@ enum Commands {
 		#[arg(help = "The hex-encoded public key of the node to disconnect from")]
 		node_pubkey: String,
 	},
+	#[command(about = "Return a list of peers")]
+	ListPeers,
 	#[command(about = "Sign a message with the node's secret key")]
 	SignMessage {
 		#[arg(help = "The message to sign")]
@@ -817,6 +819,11 @@ async fn main() {
 		Commands::DisconnectPeer { node_pubkey } => {
 			handle_response_result::<_, DisconnectPeerResponse>(
 				client.disconnect_peer(DisconnectPeerRequest { node_pubkey }).await,
+			);
+		},
+		Commands::ListPeers => {
+			handle_response_result::<_, ListPeersResponse>(
+				client.list_peers(ListPeersRequest {}).await,
 			);
 		},
 		Commands::SignMessage { message } => {

--- a/ldk-server-client/src/client.rs
+++ b/ldk-server-client/src/client.rs
@@ -22,20 +22,21 @@ use ldk_server_protos::api::{
 	GraphGetChannelResponse, GraphGetNodeRequest, GraphGetNodeResponse, GraphListChannelsRequest,
 	GraphListChannelsResponse, GraphListNodesRequest, GraphListNodesResponse, ListChannelsRequest,
 	ListChannelsResponse, ListForwardedPaymentsRequest, ListForwardedPaymentsResponse,
-	ListPaymentsRequest, ListPaymentsResponse, OnchainReceiveRequest, OnchainReceiveResponse,
-	OnchainSendRequest, OnchainSendResponse, OpenChannelRequest, OpenChannelResponse,
-	SignMessageRequest, SignMessageResponse, SpliceInRequest, SpliceInResponse, SpliceOutRequest,
-	SpliceOutResponse, SpontaneousSendRequest, SpontaneousSendResponse, UpdateChannelConfigRequest,
-	UpdateChannelConfigResponse, VerifySignatureRequest, VerifySignatureResponse,
+	ListPaymentsRequest, ListPaymentsResponse, ListPeersRequest, ListPeersResponse,
+	OnchainReceiveRequest, OnchainReceiveResponse, OnchainSendRequest, OnchainSendResponse,
+	OpenChannelRequest, OpenChannelResponse, SignMessageRequest, SignMessageResponse,
+	SpliceInRequest, SpliceInResponse, SpliceOutRequest, SpliceOutResponse, SpontaneousSendRequest,
+	SpontaneousSendResponse, UpdateChannelConfigRequest, UpdateChannelConfigResponse,
+	VerifySignatureRequest, VerifySignatureResponse,
 };
 use ldk_server_protos::endpoints::{
 	BOLT11_RECEIVE_PATH, BOLT11_SEND_PATH, BOLT12_RECEIVE_PATH, BOLT12_SEND_PATH,
 	CLOSE_CHANNEL_PATH, CONNECT_PEER_PATH, DISCONNECT_PEER_PATH, EXPORT_PATHFINDING_SCORES_PATH,
 	FORCE_CLOSE_CHANNEL_PATH, GET_BALANCES_PATH, GET_NODE_INFO_PATH, GET_PAYMENT_DETAILS_PATH,
 	GRAPH_GET_CHANNEL_PATH, GRAPH_GET_NODE_PATH, GRAPH_LIST_CHANNELS_PATH, GRAPH_LIST_NODES_PATH,
-	LIST_CHANNELS_PATH, LIST_FORWARDED_PAYMENTS_PATH, LIST_PAYMENTS_PATH, ONCHAIN_RECEIVE_PATH,
-	ONCHAIN_SEND_PATH, OPEN_CHANNEL_PATH, SIGN_MESSAGE_PATH, SPLICE_IN_PATH, SPLICE_OUT_PATH,
-	SPONTANEOUS_SEND_PATH, UPDATE_CHANNEL_CONFIG_PATH, VERIFY_SIGNATURE_PATH,
+	LIST_CHANNELS_PATH, LIST_FORWARDED_PAYMENTS_PATH, LIST_PAYMENTS_PATH, LIST_PEERS_PATH,
+	ONCHAIN_RECEIVE_PATH, ONCHAIN_SEND_PATH, OPEN_CHANNEL_PATH, SIGN_MESSAGE_PATH, SPLICE_IN_PATH,
+	SPLICE_OUT_PATH, SPONTANEOUS_SEND_PATH, UPDATE_CHANNEL_CONFIG_PATH, VERIFY_SIGNATURE_PATH,
 };
 use ldk_server_protos::error::{ErrorCode, ErrorResponse};
 use prost::Message;
@@ -274,6 +275,15 @@ impl LdkServerClient {
 		&self, request: DisconnectPeerRequest,
 	) -> Result<DisconnectPeerResponse, LdkServerError> {
 		let url = format!("https://{}/{DISCONNECT_PEER_PATH}", self.base_url);
+		self.post_request(&request, &url).await
+	}
+
+	/// Retrieves list of peers.
+	/// For API contract/usage, refer to docs for [`ListPeersRequest`] and [`ListPeersResponse`].
+	pub async fn list_peers(
+		&self, request: ListPeersRequest,
+	) -> Result<ListPeersResponse, LdkServerError> {
+		let url = format!("https://{}/{LIST_PEERS_PATH}", self.base_url);
 		self.post_request(&request, &url).await
 	}
 

--- a/ldk-server-protos/src/api.rs
+++ b/ldk-server-protos/src/api.rs
@@ -761,6 +761,24 @@ pub struct DisconnectPeerRequest {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct DisconnectPeerResponse {}
+/// Returns a list of peers.
+/// See more: <https://docs.rs/ldk-node/latest/ldk_node/struct.Node.html#method.list_peers>
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ListPeersRequest {}
+/// The response `content` for the `ListPeers` API, when HttpStatusCode is OK (200).
+/// When HttpStatusCode is not OK (non-200), the response `content` contains a serialized `ErrorResponse`.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct ListPeersResponse {
+	/// List of peers.
+	#[prost(message, repeated, tag = "1")]
+	pub peers: ::prost::alloc::vec::Vec<super::types::Peer>,
+}
 /// Returns a list of all known short channel IDs in the network graph.
 /// See more: <https://docs.rs/ldk-node/latest/ldk_node/graph/struct.NetworkGraph.html#method.list_channels>
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/ldk-server-protos/src/endpoints.rs
+++ b/ldk-server-protos/src/endpoints.rs
@@ -25,6 +25,7 @@ pub const LIST_PAYMENTS_PATH: &str = "ListPayments";
 pub const LIST_FORWARDED_PAYMENTS_PATH: &str = "ListForwardedPayments";
 pub const UPDATE_CHANNEL_CONFIG_PATH: &str = "UpdateChannelConfig";
 pub const GET_PAYMENT_DETAILS_PATH: &str = "GetPaymentDetails";
+pub const LIST_PEERS_PATH: &str = "ListPeers";
 pub const CONNECT_PEER_PATH: &str = "ConnectPeer";
 pub const DISCONNECT_PEER_PATH: &str = "DisconnectPeer";
 pub const SPONTANEOUS_SEND_PATH: &str = "SpontaneousSend";

--- a/ldk-server-protos/src/proto/api.proto
+++ b/ldk-server-protos/src/proto/api.proto
@@ -597,6 +597,18 @@ message DisconnectPeerRequest {
 // When HttpStatusCode is not OK (non-200), the response `content` contains a serialized `ErrorResponse`.
 message DisconnectPeerResponse {}
 
+// Returns a list of peers.
+// See more: https://docs.rs/ldk-node/latest/ldk_node/struct.Node.html#method.list_peers
+message ListPeersRequest {}
+
+// The response `content` for the `ListPeers` API, when HttpStatusCode is OK (200).
+// When HttpStatusCode is not OK (non-200), the response `content` contains a serialized `ErrorResponse`.
+message ListPeersResponse {
+
+  // List of peers.
+  repeated types.Peer peers = 1;
+}
+
 // Returns a list of all known short channel IDs in the network graph.
 // See more: https://docs.rs/ldk-node/latest/ldk_node/graph/struct.NetworkGraph.html#method.list_channels
 message GraphListChannelsRequest {}

--- a/ldk-server-protos/src/proto/types.proto
+++ b/ldk-server-protos/src/proto/types.proto
@@ -792,6 +792,22 @@ message GraphNodeAnnouncement {
   repeated string addresses = 4;
 }
 
+// Details of a known Lightning peer.
+// See more: https://docs.rs/ldk-node/latest/ldk_node/struct.Node.html#method.list_peers
+message Peer {
+  // The hex-encoded node ID of the peer.
+  string node_id = 1;
+
+  // The network address of the peer.
+  string address = 2;
+
+  // Indicates whether we'll try to reconnect to this peer after restarts.
+  bool is_persisted = 3;
+
+  // Indicates whether we currently have an active connection with the peer.
+  bool is_connected = 4;
+}
+
 // Details about a node in the network graph, known from the network announcement.
 message GraphNode {
   // All valid channels a node has announced.

--- a/ldk-server-protos/src/types.rs
+++ b/ldk-server-protos/src/types.rs
@@ -1000,6 +1000,26 @@ pub struct GraphNodeAnnouncement {
 	#[prost(string, repeated, tag = "4")]
 	pub addresses: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
 }
+/// Details of a known Lightning peer.
+/// See more: <https://docs.rs/ldk-node/latest/ldk_node/struct.Node.html#method.list_peers>
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct Peer {
+	/// The hex-encoded node ID of the peer.
+	#[prost(string, tag = "1")]
+	pub node_id: ::prost::alloc::string::String,
+	/// The network address of the peer.
+	#[prost(string, tag = "2")]
+	pub address: ::prost::alloc::string::String,
+	/// Indicates whether we'll try to reconnect to this peer after restarts.
+	#[prost(bool, tag = "3")]
+	pub is_persisted: bool,
+	/// Indicates whether we currently have an active connection with the peer.
+	#[prost(bool, tag = "4")]
+	pub is_connected: bool,
+}
 /// Details about a node in the network graph, known from the network announcement.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]

--- a/ldk-server/src/api/list_peers.rs
+++ b/ldk-server/src/api/list_peers.rs
@@ -1,0 +1,23 @@
+// This file is Copyright its original authors, visible in version control
+// history.
+//
+// This file is licensed under the Apache License, Version 2.0 <LICENSE-APACHE
+// or http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your option.
+// You may not use this file except in accordance with one or both of these
+// licenses.
+
+use ldk_server_protos::api::{ListPeersRequest, ListPeersResponse};
+
+use crate::api::error::LdkServerError;
+use crate::service::Context;
+use crate::util::proto_adapter::peer_to_proto;
+
+pub(crate) fn handle_list_peers_request(
+	context: Context, _request: ListPeersRequest,
+) -> Result<ListPeersResponse, LdkServerError> {
+	let peers = context.node.list_peers().into_iter().map(peer_to_proto).collect();
+
+	let response = ListPeersResponse { peers };
+	Ok(response)
+}

--- a/ldk-server/src/api/mod.rs
+++ b/ldk-server/src/api/mod.rs
@@ -33,6 +33,7 @@ pub(crate) mod graph_list_nodes;
 pub(crate) mod list_channels;
 pub(crate) mod list_forwarded_payments;
 pub(crate) mod list_payments;
+pub(crate) mod list_peers;
 pub(crate) mod onchain_receive;
 pub(crate) mod onchain_send;
 pub(crate) mod open_channel;

--- a/ldk-server/src/service.rs
+++ b/ldk-server/src/service.rs
@@ -23,9 +23,9 @@ use ldk_server_protos::endpoints::{
 	CLOSE_CHANNEL_PATH, CONNECT_PEER_PATH, DISCONNECT_PEER_PATH, EXPORT_PATHFINDING_SCORES_PATH,
 	FORCE_CLOSE_CHANNEL_PATH, GET_BALANCES_PATH, GET_NODE_INFO_PATH, GET_PAYMENT_DETAILS_PATH,
 	GRAPH_GET_CHANNEL_PATH, GRAPH_GET_NODE_PATH, GRAPH_LIST_CHANNELS_PATH, GRAPH_LIST_NODES_PATH,
-	LIST_CHANNELS_PATH, LIST_FORWARDED_PAYMENTS_PATH, LIST_PAYMENTS_PATH, ONCHAIN_RECEIVE_PATH,
-	ONCHAIN_SEND_PATH, OPEN_CHANNEL_PATH, SIGN_MESSAGE_PATH, SPLICE_IN_PATH, SPLICE_OUT_PATH,
-	SPONTANEOUS_SEND_PATH, UPDATE_CHANNEL_CONFIG_PATH, VERIFY_SIGNATURE_PATH,
+	LIST_CHANNELS_PATH, LIST_FORWARDED_PAYMENTS_PATH, LIST_PAYMENTS_PATH, LIST_PEERS_PATH,
+	ONCHAIN_RECEIVE_PATH, ONCHAIN_SEND_PATH, OPEN_CHANNEL_PATH, SIGN_MESSAGE_PATH, SPLICE_IN_PATH,
+	SPLICE_OUT_PATH, SPONTANEOUS_SEND_PATH, UPDATE_CHANNEL_CONFIG_PATH, VERIFY_SIGNATURE_PATH,
 };
 use prost::Message;
 
@@ -49,6 +49,7 @@ use crate::api::graph_list_nodes::handle_graph_list_nodes_request;
 use crate::api::list_channels::handle_list_channels_request;
 use crate::api::list_forwarded_payments::handle_list_forwarded_payments_request;
 use crate::api::list_payments::handle_list_payments_request;
+use crate::api::list_peers::handle_list_peers_request;
 use crate::api::onchain_receive::handle_onchain_receive_request;
 use crate::api::onchain_send::handle_onchain_send_request;
 use crate::api::open_channel::handle_open_channel;
@@ -310,6 +311,13 @@ impl Service<Request<Incoming>> for NodeService {
 			DISCONNECT_PEER_PATH => {
 				Box::pin(handle_request(context, req, auth_params, api_key, handle_disconnect_peer))
 			},
+			LIST_PEERS_PATH => Box::pin(handle_request(
+				context,
+				req,
+				auth_params,
+				api_key,
+				handle_list_peers_request,
+			)),
 			SPONTANEOUS_SEND_PATH => Box::pin(handle_request(
 				context,
 				req,

--- a/ldk-server/src/util/proto_adapter.rs
+++ b/ldk-server/src/util/proto_adapter.rs
@@ -22,7 +22,7 @@ use ldk_node::lightning_invoice::{Bolt11InvoiceDescription, Description, Sha256}
 use ldk_node::payment::{
 	ConfirmationStatus, PaymentDetails, PaymentDirection, PaymentKind, PaymentStatus,
 };
-use ldk_node::{ChannelDetails, LightningBalance, PendingSweepBalance, UserChannelId};
+use ldk_node::{ChannelDetails, LightningBalance, PeerDetails, PendingSweepBalance, UserChannelId};
 use ldk_server_protos::error::{ErrorCode, ErrorResponse};
 use ldk_server_protos::types::confirmation_status::Status::{Confirmed, Unconfirmed};
 use ldk_server_protos::types::lightning_balance::BalanceType::{
@@ -36,13 +36,22 @@ use ldk_server_protos::types::pending_sweep_balance::BalanceType::{
 	AwaitingThresholdConfirmations, BroadcastAwaitingConfirmation, PendingBroadcast,
 };
 use ldk_server_protos::types::{
-	bolt11_invoice_description, Channel, ForwardedPayment, LspFeeLimits, OutPoint, Payment,
+	bolt11_invoice_description, Channel, ForwardedPayment, LspFeeLimits, OutPoint, Payment, Peer,
 };
 
 use crate::api::error::LdkServerError;
 use crate::api::error::LdkServerErrorCode::{
 	AuthError, InternalServerError, InvalidRequestError, LightningError,
 };
+
+pub(crate) fn peer_to_proto(peer: PeerDetails) -> Peer {
+	Peer {
+		node_id: peer.node_id.to_string(),
+		address: peer.address.to_string(),
+		is_persisted: peer.is_persisted,
+		is_connected: peer.is_connected,
+	}
+}
 
 pub(crate) fn channel_to_proto(channel: ChannelDetails) -> Channel {
 	Channel {


### PR DESCRIPTION
Add a new ListPeers endpoint that returns all known peers with their node ID, address, persistence, and connection status.