### PR TITLE
Add CI job to verify generated protobuf files are up to date

### DIFF
--- a/.github/workflows/check-protos.yml
+++ b/.github/workflows/check-protos.yml
@@ -1,0 +1,32 @@
+name: Check Generated Protos
+
+on:
+  push:
+    paths:
+      - 'ldk-server-protos/**'
+  pull_request:
+    paths:
+      - 'ldk-server-protos/**'
+  workflow_dispatch:
+
+jobs:
+  check-protos:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v3
+      - name: Install Rust stable toolchain
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile=minimal --default-toolchain stable
+      - name: Install protoc
+        run: sudo apt-get install -y protobuf-compiler
+      - name: Generate protos
+        run: RUSTFLAGS="--cfg genproto" cargo build -p ldk-server-protos
+      - name: Format generated code
+        run: rustup component add rustfmt && cargo fmt --all
+      - name: Check for differences
+        run: |
+          if ! git diff --exit-code; then
+            echo "error: Generated protobuf files are out of date. Run: RUSTFLAGS=\"--cfg genproto\" cargo build -p ldk-server-protos && cargo fmt --all"
+            exit 1
+          fi

--- a/ldk-server-protos/src/types.rs
+++ b/ldk-server-protos/src/types.rs
@@ -1081,7 +1081,6 @@ impl PaymentStatus {
 		}
 	}
 }
-
 /// Indicates whether the balance is derived from a cooperative close, a force-close (for holder or counterparty),
 /// or whether it is for an HTLC.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -1098,7 +1097,6 @@ pub enum BalanceSource {
 	/// This balance is the result of an HTLC.
 	Htlc = 3,
 }
-
 impl BalanceSource {
 	/// String value of the enum field names used in the ProtoBuf definition.
 	///


### PR DESCRIPTION
Runs proto generation and checks for uncommitted diffs whenever files in ldk-server-protos/ are changed. Now we will know if the generated files were correctly updated when we edit the protobufs.

This found a formatting issue in the types.rs for me.