### PR TITLE
Reject invalid parameters instead of silently dropping them

### DIFF
--- a/ldk-server-cli/src/main.rs
+++ b/ldk-server-cli/src/main.rs
@@ -779,6 +779,11 @@ async fn main() {
 			);
 		},
 		Commands::Bolt12Receive { description, amount, expiry_secs, quantity } => {
+			if quantity.is_some() && amount.is_none() {
+				handle_error_msg(
+					"quantity can only be set for fixed-amount offers (amount must be provided)",
+				);
+			}
 			let amount_msat = amount.map(|a| a.to_msat());
 			handle_response_result::<_, Bolt12ReceiveResponse>(
 				client

--- a/ldk-server/src/api/bolt12_receive.rs
+++ b/ldk-server/src/api/bolt12_receive.rs
@@ -13,23 +13,29 @@ use hex::DisplayHex;
 use ldk_server_grpc::api::{Bolt12ReceiveRequest, Bolt12ReceiveResponse};
 
 use crate::api::error::LdkServerError;
+use crate::api::error::LdkServerErrorCode::InvalidRequestError;
 use crate::service::Context;
 
 pub(crate) async fn handle_bolt12_receive_request(
 	context: Arc<Context>, request: Bolt12ReceiveRequest,
 ) -> Result<Bolt12ReceiveResponse, LdkServerError> {
-	let offer = match request.amount_msat {
-		Some(amount_msat) => context.node.bolt12_payment().receive(
-			amount_msat,
-			&request.description,
-			request.expiry_secs,
-			request.quantity,
-		)?,
-		None => context
-			.node
-			.bolt12_payment()
-			.receive_variable_amount(&request.description, request.expiry_secs)?,
-	};
+	let offer =
+		match (request.amount_msat, request.quantity) {
+			(Some(amount_msat), quantity) => context.node.bolt12_payment().receive(
+				amount_msat,
+				&request.description,
+				request.expiry_secs,
+				quantity,
+			)?,
+			(None, Some(_)) => return Err(LdkServerError::new(
+				InvalidRequestError,
+				"quantity can only be set for fixed-amount offers (amount_msat must be provided)",
+			)),
+			(None, None) => context
+				.node
+				.bolt12_payment()
+				.receive_variable_amount(&request.description, request.expiry_secs)?,
+		};
 
 	let offer_id = offer.id().0.to_lower_hex_string();
 	let response = Bolt12ReceiveResponse { offer: offer.to_string(), offer_id };

--- a/ldk-server/src/api/onchain_send.rs
+++ b/ldk-server/src/api/onchain_send.rs
@@ -30,7 +30,12 @@ pub(crate) async fn handle_onchain_send_request(
 			)
 		})?;
 
-	let fee_rate = request.fee_rate_sat_per_vb.and_then(FeeRate::from_sat_per_vb);
+	let fee_rate = match request.fee_rate_sat_per_vb {
+		Some(rate) => Some(FeeRate::from_sat_per_vb(rate).ok_or_else(|| {
+			LdkServerError::new(InvalidRequestError, format!("Invalid fee rate: {} sat/vB", rate))
+		})?),
+		None => None,
+	};
 	let txid = match (request.amount_sats, request.send_all) {
 		(Some(amount_sats), None) => {
 			context.node.onchain_payment().send_to_address(&address, amount_sats, fee_rate)?


### PR DESCRIPTION
Previously, `onchain_send` silently fell back to the node's default fee estimation when given an invalid `fee_rate_sat_per_vb` (e.g., overflows), and `bolt12_receive` silently dropped the `quantity` parameter when `amount_msat` was not set. Both cases now return an error instead.

Matching CLI-side validation added for both cases.