### PR TITLE
Add `OpenChannel::disable_counterparty_reserve`

### DIFF
--- a/e2e-tests/src/lib.rs
+++ b/e2e-tests/src/lib.rs
@@ -428,6 +428,7 @@ pub async fn setup_funded_channel(
 			push_to_counterparty_msat: None,
 			channel_config: None,
 			announce_channel: true,
+			disable_counterparty_reserve: false,
 		})
 		.await
 		.unwrap();

--- a/ldk-server-cli/src/main.rs
+++ b/ldk-server-cli/src/main.rs
@@ -389,6 +389,11 @@ enum Commands {
 		push_to_counterparty: Option<Amount>,
 		#[arg(long, help = "Whether the channel should be public")]
 		announce_channel: bool,
+		#[arg(
+			long,
+			help = "Allow the counterparty to spend all its channel balance. This cannot be set together with `announce_channel`."
+		)]
+		disable_counterparty_reserve: bool,
 		// Channel config options
 		#[arg(
 			long,
@@ -914,6 +919,7 @@ async fn main() {
 			channel_amount,
 			push_to_counterparty,
 			announce_channel,
+			disable_counterparty_reserve,
 			forwarding_fee_proportional_millionths,
 			forwarding_fee_base_msat,
 			cltv_expiry_delta,
@@ -926,6 +932,12 @@ async fn main() {
 				forwarding_fee_base_msat,
 				cltv_expiry_delta,
 			);
+			if announce_channel && disable_counterparty_reserve {
+				handle_error(LdkServerError::new(
+					InvalidRequestError,
+					"Cannot set both `announce_channel` and `disable_counterparty_reserve`",
+				));
+			}
 
 			handle_response_result::<_, OpenChannelResponse>(
 				client
@@ -936,6 +948,7 @@ async fn main() {
 						push_to_counterparty_msat,
 						channel_config,
 						announce_channel,
+						disable_counterparty_reserve,
 					})
 					.await,
 			);

--- a/ldk-server-cli/src/main.rs
+++ b/ldk-server-cli/src/main.rs
@@ -681,7 +681,7 @@ async fn main() {
 				}),
 				(Some(_), Some(_)) => {
 					handle_error(LdkServerError::new(
-						InternalError,
+						InvalidRequestError,
 						"Only one of description or description_hash can be set.".to_string(),
 					));
 				},
@@ -1250,7 +1250,7 @@ fn parse_bolt11_invoice_description(
 		}),
 		(Some(_), Some(_)) => {
 			handle_error(LdkServerError::new(
-				InternalError,
+				InvalidRequestError,
 				"Only one of description or description_hash can be set.".to_string(),
 			));
 		},
@@ -1262,13 +1262,13 @@ fn parse_page_token(token_str: &str) -> Result<PageToken, LdkServerError> {
 	let parts: Vec<&str> = token_str.split(':').collect();
 	if parts.len() != 2 {
 		return Err(LdkServerError::new(
-			InternalError,
+			InvalidRequestError,
 			"Page token must be in format 'token:index'".to_string(),
 		));
 	}
-	let index = parts[1]
-		.parse::<i64>()
-		.map_err(|_| LdkServerError::new(InternalError, "Invalid page token index".to_string()))?;
+	let index = parts[1].parse::<i64>().map_err(|_| {
+		LdkServerError::new(InvalidRequestError, "Invalid page token index".to_string())
+	})?;
 	Ok(PageToken { token: parts[0].to_string(), index })
 }
 

--- a/ldk-server-grpc/src/api.rs
+++ b/ldk-server-grpc/src/api.rs
@@ -478,6 +478,9 @@ pub struct OpenChannelRequest {
 	/// Whether the channel should be public.
 	#[prost(bool, tag = "6")]
 	pub announce_channel: bool,
+	/// Allow the counterparty to spend all its channel balance. This cannot be set together with `announce_channel`.
+	#[prost(bool, tag = "7")]
+	pub disable_counterparty_reserve: bool,
 }
 /// The response for the `OpenChannel` RPC. On failure, a gRPC error status is returned.
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]

--- a/ldk-server-grpc/src/proto/api.proto
+++ b/ldk-server-grpc/src/proto/api.proto
@@ -395,6 +395,9 @@ message OpenChannelRequest {
 
   // Whether the channel should be public.
   bool announce_channel = 6;
+
+  // Allow the counterparty to spend all its channel balance. This cannot be set together with `announce_channel`.
+  bool disable_counterparty_reserve = 7;
 }
 
 // The response for the `OpenChannel` RPC. On failure, a gRPC error status is returned.

--- a/ldk-server/src/api/open_channel.rs
+++ b/ldk-server/src/api/open_channel.rs
@@ -16,7 +16,7 @@ use ldk_node::lightning::ln::msgs::SocketAddress;
 use ldk_server_grpc::api::{OpenChannelRequest, OpenChannelResponse};
 
 use crate::api::build_channel_config_from_proto;
-use crate::api::error::LdkServerError;
+use crate::api::error::{LdkServerError, LdkServerErrorCode};
 use crate::service::Context;
 
 pub(crate) async fn handle_open_channel(
@@ -26,6 +26,12 @@ pub(crate) async fn handle_open_channel(
 		.map_err(|_| ldk_node::NodeError::InvalidPublicKey)?;
 	let address = SocketAddress::from_str(&request.address)
 		.map_err(|_| ldk_node::NodeError::InvalidSocketAddress)?;
+	if request.announce_channel && request.disable_counterparty_reserve {
+		return Err(LdkServerError::new(
+			LdkServerErrorCode::InvalidRequestError,
+			"Cannot set both `announce_channel` and `disable_counterparty_reserve`",
+		));
+	}
 
 	let channel_config = request
 		.channel_config
@@ -34,6 +40,14 @@ pub(crate) async fn handle_open_channel(
 
 	let user_channel_id = if request.announce_channel {
 		context.node.open_announced_channel(
+			node_id,
+			address,
+			request.channel_amount_sats,
+			request.push_to_counterparty_msat,
+			channel_config,
+		)?
+	} else if request.disable_counterparty_reserve {
+		context.node.open_0reserve_channel(
 			node_id,
 			address,
 			request.channel_amount_sats,


### PR DESCRIPTION
When set, the counterparty will be allowed to spend its entire balance in the channel.

This setting cannot be set together with `announce_channel`.