### PR TITLE
Add `network` field to `GetNodeInfoResponse`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,7 +272,7 @@ checksum = "0b47c4ab7a93edb0c7198c5535ed9b52b63095f4e9b45279c6736cec4b856baf"
 [[package]]
 name = "bitcoin-payment-instructions"
 version = "0.6.0"
-source = "git+https://github.com/jkczyz/bitcoin-payment-instructions?rev=a7b32d5fded9bb45f73bf82e6d7187adf705171c#a7b32d5fded9bb45f73bf82e6d7187adf705171c"
+source = "git+https://github.com/jkczyz/bitcoin-payment-instructions?rev=679dac50cc0d81ec4d31da94b93d467e5308f16a#679dac50cc0d81ec4d31da94b93d467e5308f16a"
 dependencies = [
  "bitcoin",
  "dnssec-prover",
@@ -1203,7 +1203,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "ldk-node"
 version = "0.8.0+git"
-source = "git+https://github.com/lightningdevkit/ldk-node?rev=21eea8c881790db7a90bcad4f7f45f341c72222b#21eea8c881790db7a90bcad4f7f45f341c72222b"
+source = "git+https://github.com/lightningdevkit/ldk-node?rev=16eaa6f46308965f501904506be3ceecd293f358#16eaa6f46308965f501904506be3ceecd293f358"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1343,7 +1343,7 @@ dependencies = [
 [[package]]
 name = "lightning"
 version = "0.3.0+git"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=38a62c32454d3eac22578144c479dbf9a6d9bff6#38a62c32454d3eac22578144c479dbf9a6d9bff6"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=369a2cf9c8ef810deea0cd2b4cf6ed0691b78144#369a2cf9c8ef810deea0cd2b4cf6ed0691b78144"
 dependencies = [
  "bech32",
  "bitcoin",
@@ -1359,7 +1359,7 @@ dependencies = [
 [[package]]
 name = "lightning-background-processor"
 version = "0.3.0+git"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=38a62c32454d3eac22578144c479dbf9a6d9bff6#38a62c32454d3eac22578144c479dbf9a6d9bff6"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=369a2cf9c8ef810deea0cd2b4cf6ed0691b78144#369a2cf9c8ef810deea0cd2b4cf6ed0691b78144"
 dependencies = [
  "bitcoin",
  "bitcoin-io",
@@ -1373,7 +1373,7 @@ dependencies = [
 [[package]]
 name = "lightning-block-sync"
 version = "0.3.0+git"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=38a62c32454d3eac22578144c479dbf9a6d9bff6#38a62c32454d3eac22578144c479dbf9a6d9bff6"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=369a2cf9c8ef810deea0cd2b4cf6ed0691b78144#369a2cf9c8ef810deea0cd2b4cf6ed0691b78144"
 dependencies = [
  "bitcoin",
  "bitreq",
@@ -1385,7 +1385,7 @@ dependencies = [
 [[package]]
 name = "lightning-dns-resolver"
 version = "0.3.0+git"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=38a62c32454d3eac22578144c479dbf9a6d9bff6#38a62c32454d3eac22578144c479dbf9a6d9bff6"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=369a2cf9c8ef810deea0cd2b4cf6ed0691b78144#369a2cf9c8ef810deea0cd2b4cf6ed0691b78144"
 dependencies = [
  "dnssec-prover",
  "lightning",
@@ -1396,7 +1396,7 @@ dependencies = [
 [[package]]
 name = "lightning-invoice"
 version = "0.35.0+git"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=38a62c32454d3eac22578144c479dbf9a6d9bff6#38a62c32454d3eac22578144c479dbf9a6d9bff6"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=369a2cf9c8ef810deea0cd2b4cf6ed0691b78144#369a2cf9c8ef810deea0cd2b4cf6ed0691b78144"
 dependencies = [
  "bech32",
  "bitcoin",
@@ -1407,7 +1407,7 @@ dependencies = [
 [[package]]
 name = "lightning-liquidity"
 version = "0.3.0+git"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=38a62c32454d3eac22578144c479dbf9a6d9bff6#38a62c32454d3eac22578144c479dbf9a6d9bff6"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=369a2cf9c8ef810deea0cd2b4cf6ed0691b78144#369a2cf9c8ef810deea0cd2b4cf6ed0691b78144"
 dependencies = [
  "bitcoin",
  "chrono",
@@ -1422,7 +1422,7 @@ dependencies = [
 [[package]]
 name = "lightning-macros"
 version = "0.2.2+git"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=38a62c32454d3eac22578144c479dbf9a6d9bff6#38a62c32454d3eac22578144c479dbf9a6d9bff6"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=369a2cf9c8ef810deea0cd2b4cf6ed0691b78144#369a2cf9c8ef810deea0cd2b4cf6ed0691b78144"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1432,7 +1432,7 @@ dependencies = [
 [[package]]
 name = "lightning-net-tokio"
 version = "0.3.0+git"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=38a62c32454d3eac22578144c479dbf9a6d9bff6#38a62c32454d3eac22578144c479dbf9a6d9bff6"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=369a2cf9c8ef810deea0cd2b4cf6ed0691b78144#369a2cf9c8ef810deea0cd2b4cf6ed0691b78144"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1442,7 +1442,7 @@ dependencies = [
 [[package]]
 name = "lightning-persister"
 version = "0.3.0+git"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=38a62c32454d3eac22578144c479dbf9a6d9bff6#38a62c32454d3eac22578144c479dbf9a6d9bff6"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=369a2cf9c8ef810deea0cd2b4cf6ed0691b78144#369a2cf9c8ef810deea0cd2b4cf6ed0691b78144"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1453,7 +1453,7 @@ dependencies = [
 [[package]]
 name = "lightning-rapid-gossip-sync"
 version = "0.3.0+git"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=38a62c32454d3eac22578144c479dbf9a6d9bff6#38a62c32454d3eac22578144c479dbf9a6d9bff6"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=369a2cf9c8ef810deea0cd2b4cf6ed0691b78144#369a2cf9c8ef810deea0cd2b4cf6ed0691b78144"
 dependencies = [
  "bitcoin",
  "bitcoin-io",
@@ -1464,7 +1464,7 @@ dependencies = [
 [[package]]
 name = "lightning-transaction-sync"
 version = "0.3.0+git"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=38a62c32454d3eac22578144c479dbf9a6d9bff6#38a62c32454d3eac22578144c479dbf9a6d9bff6"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=369a2cf9c8ef810deea0cd2b4cf6ed0691b78144#369a2cf9c8ef810deea0cd2b4cf6ed0691b78144"
 dependencies = [
  "bitcoin",
  "electrum-client",
@@ -1477,7 +1477,7 @@ dependencies = [
 [[package]]
 name = "lightning-types"
 version = "0.4.0+git"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=38a62c32454d3eac22578144c479dbf9a6d9bff6#38a62c32454d3eac22578144c479dbf9a6d9bff6"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=369a2cf9c8ef810deea0cd2b4cf6ed0691b78144#369a2cf9c8ef810deea0cd2b4cf6ed0691b78144"
 dependencies = [
  "bitcoin",
 ]
@@ -1636,7 +1636,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 [[package]]
 name = "possiblyrandom"
 version = "0.2.0"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=38a62c32454d3eac22578144c479dbf9a6d9bff6#38a62c32454d3eac22578144c479dbf9a6d9bff6"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=369a2cf9c8ef810deea0cd2b4cf6ed0691b78144#369a2cf9c8ef810deea0cd2b4cf6ed0691b78144"
 dependencies = [
  "getrandom 0.2.16",
 ]

--- a/ldk-server-grpc/build.rs
+++ b/ldk-server-grpc/build.rs
@@ -69,6 +69,10 @@ fn generate_protos() {
 			"types.ClaimableAwaitingConfirmations.source",
 			"#[cfg_attr(feature = \"serde\", serde(serialize_with = \"crate::serde_utils::serialize_balance_source\"))]",
 		)
+        .field_attribute(
+            "api.GetNodeInfoResponse.network",
+            "#[cfg_attr(feature = \"serde\", serde(serialize_with = \"crate::serde_utils::serialize_network\"))]",
+        )
 		.field_attribute(
 			"api.UnifiedSendResponse.payment_result",
 			"#[cfg_attr(feature = \"serde\", serde(flatten))]",

--- a/ldk-server-grpc/src/api.rs
+++ b/ldk-server-grpc/src/api.rs
@@ -79,6 +79,10 @@ pub struct GetNodeInfoResponse {
 	/// Will be empty if no announcement addresses are configured.
 	#[prost(string, repeated, tag = "12")]
 	pub node_uris: ::prost::alloc::vec::Vec<::prost::alloc::string::String>,
+	/// The Bitcoin network the node is running on (e.g., "bitcoin", "testnet", "signet", "regtest").
+	#[prost(enumeration = "super::types::Network", tag = "13")]
+	#[cfg_attr(feature = "serde", serde(serialize_with = "crate::serde_utils::serialize_network"))]
+	pub network: i32,
 }
 /// Retrieve a new on-chain funding address.
 /// See more: <https://docs.rs/ldk-node/latest/ldk_node/payment/struct.OnchainPayment.html#method.new_address>

--- a/ldk-server-grpc/src/proto/api.proto
+++ b/ldk-server-grpc/src/proto/api.proto
@@ -70,6 +70,9 @@ message GetNodeInfoResponse {
   // These are constructed from the announcement addresses and the node's public key.
   // Will be empty if no announcement addresses are configured.
   repeated string node_uris = 12;
+
+  // The Bitcoin network the node is running on (e.g., "bitcoin", "testnet", "signet", "regtest").
+  types.Network network = 13;
 }
 
 // Retrieve a new on-chain funding address.

--- a/ldk-server-grpc/src/proto/types.proto
+++ b/ldk-server-grpc/src/proto/types.proto
@@ -201,6 +201,24 @@ enum PaymentStatus {
   FAILED = 2;
 }
 
+// The Bitcoin network the node is running on.
+enum Network {
+  // Mainnet Bitcoin.
+  BITCOIN = 0;
+
+  // Bitcoin's testnet (testnet3) network.
+  TESTNET = 1;
+
+  // Bitcoin's testnet4 network.
+  TESTNET4 = 2;
+
+  // Bitcoin's signet network.
+  SIGNET = 3;
+
+  // Bitcoin's regtest network.
+  REGTEST = 4;
+}
+
 // A forwarded payment through our node.
 // See more: https://docs.rs/ldk-node/latest/ldk_node/enum.Event.html#variant.PaymentForwarded
 message ForwardedPayment{

--- a/ldk-server-grpc/src/serde_utils.rs
+++ b/ldk-server-grpc/src/serde_utils.rs
@@ -37,6 +37,7 @@ macro_rules! stringify_enum_serializer {
 stringify_enum_serializer!(serialize_payment_direction, crate::types::PaymentDirection);
 stringify_enum_serializer!(serialize_payment_status, crate::types::PaymentStatus);
 stringify_enum_serializer!(serialize_balance_source, crate::types::BalanceSource);
+stringify_enum_serializer!(serialize_network, crate::types::Network);
 
 /// Serializes `Option<prost::bytes::Bytes>` as a hex string (or null).
 pub fn serialize_opt_bytes_hex<S>(

--- a/ldk-server-grpc/src/types.rs
+++ b/ldk-server-grpc/src/types.rs
@@ -1234,6 +1234,49 @@ impl PaymentStatus {
 		}
 	}
 }
+/// The Bitcoin network the node is running on.
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+#[repr(i32)]
+pub enum Network {
+	/// Mainnet Bitcoin.
+	Bitcoin = 0,
+	/// Bitcoin's testnet (testnet3) network.
+	Testnet = 1,
+	/// Bitcoin's testnet4 network.
+	Testnet4 = 2,
+	/// Bitcoin's signet network.
+	Signet = 3,
+	/// Bitcoin's regtest network.
+	Regtest = 4,
+}
+impl Network {
+	/// String value of the enum field names used in the ProtoBuf definition.
+	///
+	/// The values are not transformed in any way and thus are considered stable
+	/// (if the ProtoBuf definition does not change) and safe for programmatic use.
+	pub fn as_str_name(&self) -> &'static str {
+		match self {
+			Network::Bitcoin => "BITCOIN",
+			Network::Testnet => "TESTNET",
+			Network::Testnet4 => "TESTNET4",
+			Network::Signet => "SIGNET",
+			Network::Regtest => "REGTEST",
+		}
+	}
+	/// Creates an enum from field names used in the ProtoBuf definition.
+	pub fn from_str_name(value: &str) -> ::core::option::Option<Self> {
+		match value {
+			"BITCOIN" => Some(Self::Bitcoin),
+			"TESTNET" => Some(Self::Testnet),
+			"TESTNET4" => Some(Self::Testnet4),
+			"SIGNET" => Some(Self::Signet),
+			"REGTEST" => Some(Self::Regtest),
+			_ => None,
+		}
+	}
+}
 /// Indicates whether the balance is derived from a cooperative close, a force-close (for holder or counterparty),
 /// or whether it is for an HTLC.
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]

--- a/ldk-server/Cargo.toml
+++ b/ldk-server/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-ldk-node = { git = "https://github.com/lightningdevkit/ldk-node", rev = "21eea8c881790db7a90bcad4f7f45f341c72222b" }
+ldk-node = { git = "https://github.com/lightningdevkit/ldk-node", rev = "16eaa6f46308965f501904506be3ceecd293f358" }
 serde = { version = "1.0.203", default-features = false, features = ["derive"] }
 hyper = { version = "1", default-features = false, features = ["server", "http2"] }
 http-body-util = { version = "0.1", default-features = false }

--- a/ldk-server/src/api/get_node_info.rs
+++ b/ldk-server/src/api/get_node_info.rs
@@ -14,6 +14,7 @@ use ldk_server_grpc::types::BestBlock;
 
 use crate::api::error::LdkServerError;
 use crate::service::Context;
+use crate::util::proto_adapter::network_to_proto;
 
 pub(crate) async fn handle_get_node_info_request(
 	context: Arc<Context>, _request: GetNodeInfoRequest,
@@ -49,6 +50,8 @@ pub(crate) async fn handle_get_node_info_request(
 		};
 		addrs.into_iter().map(|a| format!("{node_id}@{a}")).collect()
 	};
+	let network = network_to_proto(node_status.network) as i32;
+
 	let response = GetNodeInfoResponse {
 		node_id,
 		current_best_block: Some(best_block),
@@ -62,6 +65,7 @@ pub(crate) async fn handle_get_node_info_request(
 		announcement_addresses,
 		node_alias,
 		node_uris,
+		network,
 	};
 	Ok(response)
 }

--- a/ldk-server/src/util/proto_adapter.rs
+++ b/ldk-server/src/util/proto_adapter.rs
@@ -11,6 +11,7 @@ use bytes::Bytes;
 use hex::prelude::*;
 use ldk_node::bitcoin::hashes::sha256;
 use ldk_node::bitcoin::secp256k1::PublicKey;
+use ldk_node::bitcoin::Network;
 use ldk_node::config::{ChannelConfig, MaxDustHTLCExposure};
 use ldk_node::lightning::chain::channelmonitor::BalanceSource;
 use ldk_node::lightning::ln::types::ChannelId;
@@ -508,5 +509,16 @@ pub(crate) fn graph_node_to_proto(node: NodeInfo) -> ldk_server_grpc::types::Gra
 	ldk_server_grpc::types::GraphNode {
 		channels: node.channels,
 		announcement_info: node.announcement_info.map(graph_node_announcement_to_proto),
+	}
+}
+
+pub(crate) fn network_to_proto(network: Network) -> ldk_server_grpc::types::Network {
+	use ldk_server_grpc::types::Network as ProtoNetwork;
+	match network {
+		Network::Bitcoin => ProtoNetwork::Bitcoin,
+		Network::Testnet => ProtoNetwork::Testnet,
+		Network::Testnet4 => ProtoNetwork::Testnet4,
+		Network::Signet => ProtoNetwork::Signet,
+		Network::Regtest => ProtoNetwork::Regtest,
 	}
 }


### PR DESCRIPTION
Expose the Bitcoin network the node is running on (e.g., "bitcoin", "testnet", "signet", "regtest") via the get-node-info API.

This was merged in https://github.com/lightningdevkit/ldk-node/pull/892

I've bumped the dependency revision of ldk-node to the latest one before breaking changes are introduced (https://github.com/lightningdevkit/ldk-node/pull/850). 