### PR TITLE
Add security documentation

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Security vulnerabilities for `ldk-server` are handled under the same policy as
+`rust-lightning`(LDK), on which this library is built.
+
+Please refer to the [rust-lightning's SECURITY.md](https://github.com/lightningdevkit/rust-lightning/blob/main/SECURITY.md)
+for instructions on how to responsibly disclose vulnerabilities.


### PR DESCRIPTION
Closes #191 
Added SECURITY.md. For now it just says that we follow the same security policy as rust-lightning but open to any furhter changes the maintainers feel necessary.