### PR TITLE
Display compressed public keys in info logs

### DIFF
--- a/ldk-server/src/main.rs
+++ b/ldk-server/src/main.rs
@@ -376,7 +376,7 @@ fn main() {
 							} => {
 								info!(
 									"CHANNEL_READY: {} from counterparty {:?}",
-									channel_id, counterparty_node_id
+									channel_id, counterparty_node_id.map(|p| p.to_string()),
 								);
 
 								let channel_id_hex = channel_id.0.to_lower_hex_string();
@@ -412,7 +412,7 @@ fn main() {
 							} => {
 								info!(
 									"CHANNEL_CLOSED: {} from counterparty {:?}",
-									channel_id, counterparty_node_id
+									channel_id, counterparty_node_id.map(|p| p.to_string()),
 								);
 
 								let channel_id_hex = channel_id.0.to_lower_hex_string();


### PR DESCRIPTION
```
    Display compressed public keys in info logs

    Uncompressed public keys are not very helpful, especially since our
    `list-peers` command displays compressed public keys for node ids.
```