### PR TITLE
Add crate version and commit hash to ldk-server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM rust:1.85 AS builder
 
 WORKDIR /app
 ARG ENABLE_LSPS2=false
+ARG GIT_HASH
+ENV GIT_HASH=$GIT_HASH
 
 # Copy manifests and lock file first for dependency caching
 COPY Cargo.toml Cargo.lock ./

--- a/ldk-server-cli/build.rs
+++ b/ldk-server-cli/build.rs
@@ -1,0 +1,58 @@
+// This file is Copyright its original authors, visible in version control
+// history.
+//
+// This file is licensed under the Apache License, Version 2.0 <LICENSE-APACHE
+// or http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your option.
+// You may not use this file except in accordance with one or both of these
+// licenses.
+
+use std::env;
+use std::path::Path;
+use std::process::Command;
+
+fn main() {
+	println!("cargo:rerun-if-changed=build.rs");
+	println!("cargo:rerun-if-env-changed=GIT_HASH");
+
+	// Re-run the build script whenever the checked-out commit changes so the
+	// embedded hash never goes stale. HEAD lives in the (possibly worktree-local)
+	// git dir, while branch refs and packed-refs live in the common git dir.
+	if let Some(git_dir) = git_output(&["rev-parse", "--git-dir"]) {
+		watch_path(&Path::new(&git_dir).join("HEAD"));
+	}
+	if let Some(common_dir) = git_output(&["rev-parse", "--git-common-dir"]) {
+		let common_dir = Path::new(&common_dir);
+		watch_path(&common_dir.join("packed-refs"));
+		// If HEAD points at a ref, watch that ref file too (it changes on commit).
+		// Watch it even when it does not exist yet: packed refs become loose
+		// files on the next commit, and Cargo can detect that creation.
+		if let Some(ref_path) = git_output(&["symbolic-ref", "-q", "HEAD"]) {
+			watch_path(&common_dir.join(ref_path));
+		}
+	}
+
+	let git_hash = git_output(&["rev-parse", "HEAD"])
+		.or_else(|| env::var("GIT_HASH").ok())
+		.unwrap_or_else(|| "unknown".to_string());
+	println!("cargo:rustc-env=GIT_HASH={git_hash}");
+}
+
+/// Runs `git` with the given args, returning the trimmed stdout on success or
+/// `None` if git is unavailable, exits non-zero, or produces no output.
+fn git_output(args: &[&str]) -> Option<String> {
+	let output = Command::new("git").args(args).output().ok()?;
+	if !output.status.success() {
+		return None;
+	}
+	let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+	if stdout.is_empty() {
+		None
+	} else {
+		Some(stdout)
+	}
+}
+
+fn watch_path(path: &Path) {
+	println!("cargo:rerun-if-changed={}", path.display());
+}

--- a/ldk-server-cli/src/main.rs
+++ b/ldk-server-cli/src/main.rs
@@ -60,6 +60,8 @@ use types::{
 
 mod types;
 
+const FULL_VERSION: &str = concat!(env!("CARGO_PKG_VERSION"), " (", env!("GIT_HASH"), ")");
+
 const DEFAULT_DIR: &str = if cfg!(target_os = "macos") {
 	"~/Library/Application Support/ldk-server"
 } else if cfg!(target_os = "windows") {
@@ -71,7 +73,7 @@ const DEFAULT_DIR: &str = if cfg!(target_os = "macos") {
 #[derive(Parser, Debug)]
 #[command(
 	name = "ldk-server-cli",
-	version,
+	version = FULL_VERSION,
 	about = "CLI for interacting with an LDK Server node",
 	override_usage = "ldk-server-cli [OPTIONS] <COMMAND>"
 )]

--- a/ldk-server/build.rs
+++ b/ldk-server/build.rs
@@ -1,0 +1,58 @@
+// This file is Copyright its original authors, visible in version control
+// history.
+//
+// This file is licensed under the Apache License, Version 2.0 <LICENSE-APACHE
+// or http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your option.
+// You may not use this file except in accordance with one or both of these
+// licenses.
+
+use std::env;
+use std::path::Path;
+use std::process::Command;
+
+fn main() {
+	println!("cargo:rerun-if-changed=build.rs");
+	println!("cargo:rerun-if-env-changed=GIT_HASH");
+
+	// Re-run the build script whenever the checked-out commit changes so the
+	// embedded hash never goes stale. HEAD lives in the (possibly worktree-local)
+	// git dir, while branch refs and packed-refs live in the common git dir.
+	if let Some(git_dir) = git_output(&["rev-parse", "--git-dir"]) {
+		watch_path(&Path::new(&git_dir).join("HEAD"));
+	}
+	if let Some(common_dir) = git_output(&["rev-parse", "--git-common-dir"]) {
+		let common_dir = Path::new(&common_dir);
+		watch_path(&common_dir.join("packed-refs"));
+		// If HEAD points at a ref, watch that ref file too (it changes on commit).
+		// Watch it even when it does not exist yet: packed refs become loose
+		// files on the next commit, and Cargo can detect that creation.
+		if let Some(ref_path) = git_output(&["symbolic-ref", "-q", "HEAD"]) {
+			watch_path(&common_dir.join(ref_path));
+		}
+	}
+
+	let git_hash = git_output(&["rev-parse", "HEAD"])
+		.or_else(|| env::var("GIT_HASH").ok())
+		.unwrap_or_else(|| "unknown".to_string());
+	println!("cargo:rustc-env=GIT_HASH={git_hash}");
+}
+
+/// Runs `git` with the given args, returning the trimmed stdout on success or
+/// `None` if git is unavailable, exits non-zero, or produces no output.
+fn git_output(args: &[&str]) -> Option<String> {
+	let output = Command::new("git").args(args).output().ok()?;
+	if !output.status.success() {
+		return None;
+	}
+	let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+	if stdout.is_empty() {
+		None
+	} else {
+		Some(stdout)
+	}
+}
+
+fn watch_path(path: &Path) {
+	println!("cargo:rerun-if-changed={}", path.display());
+}

--- a/ldk-server/src/main.rs
+++ b/ldk-server/src/main.rs
@@ -57,6 +57,7 @@ use crate::util::tls::get_or_generate_tls_config;
 use crate::util::{systemd, write_new};
 
 const API_KEY_FILE: &str = "api_key";
+const FULL_VERSION: &str = concat!(env!("CARGO_PKG_VERSION"), " (", env!("GIT_HASH"), ")");
 
 pub fn get_default_data_dir() -> Option<PathBuf> {
 	#[cfg(target_os = "macos")]
@@ -240,7 +241,7 @@ fn main() {
 	let (event_sender, _) = broadcast::channel::<EventEnvelope>(1024);
 	let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
 
-	info!("Starting up...");
+	info!("Starting ldk-server version {FULL_VERSION}");
 	match node.start() {
 		Ok(()) => {},
 		Err(e) => {

--- a/ldk-server/src/util/config.rs
+++ b/ldk-server/src/util/config.rs
@@ -742,7 +742,7 @@ impl TryFrom<&LSPSClientTomlConfig> for LSPSClientConfig {
 
 #[derive(Parser, Debug)]
 #[command(
-	version,
+	version = crate::FULL_VERSION,
 	about = "LDK Server Configuration",
 	long_about = None,
 	override_usage = "ldk-server [config_path]"


### PR DESCRIPTION
We will now log the version number and commit hash when starting up. Also will give the full commit hash when doing ldk-server --version to better help debugging things.

Also does the same to the cli