### PR TITLE
Bump ldk-node dependency to `00dba456a10cb60172eaa74e0a8b11c5e0473dcc`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "axum"
 version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -165,9 +187,9 @@ dependencies = [
 
 [[package]]
 name = "bdk_electrum"
-version = "0.23.2"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b59a3f7fbe678874fa34354097644a171276e02a49934c13b3d61c54610ddf39"
+checksum = "00a9846105bf6e751adbb6946b000ff919ce24a15a941cbfe68485549b552a9c"
 dependencies = [
  "bdk_core",
  "electrum-client",
@@ -272,7 +294,7 @@ checksum = "0b47c4ab7a93edb0c7198c5535ed9b52b63095f4e9b45279c6736cec4b856baf"
 [[package]]
 name = "bitcoin-payment-instructions"
 version = "0.6.0"
-source = "git+https://github.com/jkczyz/bitcoin-payment-instructions?rev=679dac50cc0d81ec4d31da94b93d467e5308f16a#679dac50cc0d81ec4d31da94b93d467e5308f16a"
+source = "git+https://github.com/tnull/bitcoin-payment-instructions?rev=ff09ce9401afa448549a8f101172700bcd14d7bb#ff09ce9401afa448549a8f101172700bcd14d7bb"
 dependencies = [
  "bitcoin",
  "dnssec-prover",
@@ -367,6 +389,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "739eb0f94557554b3ca9a86d2d37bebd49c5e6d0c1d2bda35ba5bdac830befc2"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -387,6 +411,12 @@ name = "chacha20-poly1305"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b4b0fc281743d80256607bd65e8beedc42cb0787ea119c85b81b4c0eab85e5f"
+
+[[package]]
+name = "chacha20-poly1305"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad28386ab70dd960294556a76aaab6da2994fec47d650fd725b3012f062052a"
 
 [[package]]
 name = "chrono"
@@ -449,6 +479,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
+name = "cmake"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -486,6 +525,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -493,9 +538,9 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "electrum-client"
-version = "0.24.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ede7b07e2578a6df0093b101915c79dca0119d7f7810099ad9eef11341d2ae57"
+checksum = "1970c5d7bd9de6d4041cbfc3e46faa3e85fe7efcea2b0eb06750d3ae1ef577b7"
 dependencies = [
  "bitcoin",
  "byteorder",
@@ -591,6 +636,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -1185,6 +1236,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1203,7 +1264,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "ldk-node"
 version = "0.8.0+git"
-source = "git+https://github.com/lightningdevkit/ldk-node?rev=16eaa6f46308965f501904506be3ceecd293f358#16eaa6f46308965f501904506be3ceecd293f358"
+source = "git+https://github.com/lightningdevkit/ldk-node?rev=00dba456a10cb60172eaa74e0a8b11c5e0473dcc#00dba456a10cb60172eaa74e0a8b11c5e0473dcc"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1357,10 +1418,11 @@ dependencies = [
 [[package]]
 name = "lightning"
 version = "0.3.0+git"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=369a2cf9c8ef810deea0cd2b4cf6ed0691b78144#369a2cf9c8ef810deea0cd2b4cf6ed0691b78144"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=3dfcc4cca1866c5e5d4d4eaf3b82e09584e2ce5c#3dfcc4cca1866c5e5d4d4eaf3b82e09584e2ce5c"
 dependencies = [
  "bech32",
  "bitcoin",
+ "chacha20-poly1305 0.2.0",
  "dnssec-prover",
  "hashbrown 0.13.2",
  "libm",
@@ -1373,7 +1435,7 @@ dependencies = [
 [[package]]
 name = "lightning-background-processor"
 version = "0.3.0+git"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=369a2cf9c8ef810deea0cd2b4cf6ed0691b78144#369a2cf9c8ef810deea0cd2b4cf6ed0691b78144"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=3dfcc4cca1866c5e5d4d4eaf3b82e09584e2ce5c#3dfcc4cca1866c5e5d4d4eaf3b82e09584e2ce5c"
 dependencies = [
  "bitcoin",
  "bitcoin-io",
@@ -1387,7 +1449,7 @@ dependencies = [
 [[package]]
 name = "lightning-block-sync"
 version = "0.3.0+git"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=369a2cf9c8ef810deea0cd2b4cf6ed0691b78144#369a2cf9c8ef810deea0cd2b4cf6ed0691b78144"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=3dfcc4cca1866c5e5d4d4eaf3b82e09584e2ce5c#3dfcc4cca1866c5e5d4d4eaf3b82e09584e2ce5c"
 dependencies = [
  "bitcoin",
  "bitreq",
@@ -1399,7 +1461,7 @@ dependencies = [
 [[package]]
 name = "lightning-dns-resolver"
 version = "0.3.0+git"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=369a2cf9c8ef810deea0cd2b4cf6ed0691b78144#369a2cf9c8ef810deea0cd2b4cf6ed0691b78144"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=3dfcc4cca1866c5e5d4d4eaf3b82e09584e2ce5c#3dfcc4cca1866c5e5d4d4eaf3b82e09584e2ce5c"
 dependencies = [
  "dnssec-prover",
  "lightning",
@@ -1410,7 +1472,7 @@ dependencies = [
 [[package]]
 name = "lightning-invoice"
 version = "0.35.0+git"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=369a2cf9c8ef810deea0cd2b4cf6ed0691b78144#369a2cf9c8ef810deea0cd2b4cf6ed0691b78144"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=3dfcc4cca1866c5e5d4d4eaf3b82e09584e2ce5c#3dfcc4cca1866c5e5d4d4eaf3b82e09584e2ce5c"
 dependencies = [
  "bech32",
  "bitcoin",
@@ -1421,9 +1483,10 @@ dependencies = [
 [[package]]
 name = "lightning-liquidity"
 version = "0.3.0+git"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=369a2cf9c8ef810deea0cd2b4cf6ed0691b78144#369a2cf9c8ef810deea0cd2b4cf6ed0691b78144"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=3dfcc4cca1866c5e5d4d4eaf3b82e09584e2ce5c#3dfcc4cca1866c5e5d4d4eaf3b82e09584e2ce5c"
 dependencies = [
  "bitcoin",
+ "bitreq",
  "chrono",
  "lightning",
  "lightning-invoice",
@@ -1436,7 +1499,7 @@ dependencies = [
 [[package]]
 name = "lightning-macros"
 version = "0.2.2+git"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=369a2cf9c8ef810deea0cd2b4cf6ed0691b78144#369a2cf9c8ef810deea0cd2b4cf6ed0691b78144"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=3dfcc4cca1866c5e5d4d4eaf3b82e09584e2ce5c#3dfcc4cca1866c5e5d4d4eaf3b82e09584e2ce5c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1446,7 +1509,7 @@ dependencies = [
 [[package]]
 name = "lightning-net-tokio"
 version = "0.3.0+git"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=369a2cf9c8ef810deea0cd2b4cf6ed0691b78144#369a2cf9c8ef810deea0cd2b4cf6ed0691b78144"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=3dfcc4cca1866c5e5d4d4eaf3b82e09584e2ce5c#3dfcc4cca1866c5e5d4d4eaf3b82e09584e2ce5c"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1456,7 +1519,7 @@ dependencies = [
 [[package]]
 name = "lightning-persister"
 version = "0.3.0+git"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=369a2cf9c8ef810deea0cd2b4cf6ed0691b78144#369a2cf9c8ef810deea0cd2b4cf6ed0691b78144"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=3dfcc4cca1866c5e5d4d4eaf3b82e09584e2ce5c#3dfcc4cca1866c5e5d4d4eaf3b82e09584e2ce5c"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1467,7 +1530,7 @@ dependencies = [
 [[package]]
 name = "lightning-rapid-gossip-sync"
 version = "0.3.0+git"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=369a2cf9c8ef810deea0cd2b4cf6ed0691b78144#369a2cf9c8ef810deea0cd2b4cf6ed0691b78144"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=3dfcc4cca1866c5e5d4d4eaf3b82e09584e2ce5c#3dfcc4cca1866c5e5d4d4eaf3b82e09584e2ce5c"
 dependencies = [
  "bitcoin",
  "bitcoin-io",
@@ -1478,7 +1541,7 @@ dependencies = [
 [[package]]
 name = "lightning-transaction-sync"
 version = "0.3.0+git"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=369a2cf9c8ef810deea0cd2b4cf6ed0691b78144#369a2cf9c8ef810deea0cd2b4cf6ed0691b78144"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=3dfcc4cca1866c5e5d4d4eaf3b82e09584e2ce5c#3dfcc4cca1866c5e5d4d4eaf3b82e09584e2ce5c"
 dependencies = [
  "bitcoin",
  "electrum-client",
@@ -1491,7 +1554,7 @@ dependencies = [
 [[package]]
 name = "lightning-types"
 version = "0.4.0+git"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=369a2cf9c8ef810deea0cd2b4cf6ed0691b78144#369a2cf9c8ef810deea0cd2b4cf6ed0691b78144"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=3dfcc4cca1866c5e5d4d4eaf3b82e09584e2ce5c#3dfcc4cca1866c5e5d4d4eaf3b82e09584e2ce5c"
 dependencies = [
  "bitcoin",
 ]
@@ -1650,7 +1713,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 [[package]]
 name = "possiblyrandom"
 version = "0.2.0"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=369a2cf9c8ef810deea0cd2b4cf6ed0691b78144#369a2cf9c8ef810deea0cd2b4cf6ed0691b78144"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=3dfcc4cca1866c5e5d4d4eaf3b82e09584e2ce5c#3dfcc4cca1866c5e5d4d4eaf3b82e09584e2ce5c"
 dependencies = [
  "getrandom 0.2.16",
 ]
@@ -2061,6 +2124,7 @@ version = "0.23.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a9586e9ee2b4f8fab52a0048ca7334d7024eef48e2cb9407e3497bb7cab7fa7"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -2105,6 +2169,7 @@ version = "0.103.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -2716,7 +2781,7 @@ dependencies = [
  "bitcoin",
  "bitcoin_hashes 0.14.0",
  "bitreq",
- "chacha20-poly1305",
+ "chacha20-poly1305 0.1.2",
  "log",
  "prost",
  "prost-build",

--- a/e2e-tests/tests/e2e.rs
+++ b/e2e-tests/tests/e2e.rs
@@ -242,15 +242,14 @@ async fn test_cli_decode_invoice() {
 	assert_eq!(decoded_var["description"], "no amount");
 
 	// Test that ANSI escape sequences cannot reach the terminal via CLI output.
-	// serde_json escapes control chars (U+0000–U+001F) as \uXXXX in JSON.
 	let desc_with_ansi = "pay me\x1b[31m RED \x1b[0m";
 	let output_ansi = run_cli(&server, &["bolt11-receive", "-d", desc_with_ansi]);
 	let raw_decoded =
 		run_cli_raw(&server, &["decode-invoice", output_ansi["invoice"].as_str().unwrap()]);
 	assert!(!raw_decoded.contains('\x1b'), "Raw CLI output must not contain ANSI escape bytes");
 
-	// Test that Unicode bidi override characters in the description are escaped
-	// (sanitize_for_terminal replaces them with \uXXXX in CLI output)
+	// LDK exposes invoice descriptions through UntrustedString, which may replace
+	// bidi controls before the CLI sanitizer sees them.
 	let desc_with_bidi = "pay me\u{202E}evil";
 	let output_bidi = run_cli(&server, &["bolt11-receive", "-d", desc_with_bidi]);
 	let raw_bidi =
@@ -259,7 +258,6 @@ async fn test_cli_decode_invoice() {
 		!raw_bidi.contains('\u{202E}'),
 		"Raw CLI output must not contain bidi override characters"
 	);
-	assert!(raw_bidi.contains("\\u202E"), "Bidi characters should be escaped as \\uXXXX in output");
 }
 
 #[tokio::test]
@@ -336,11 +334,12 @@ async fn test_cli_decode_offer() {
 	let output_bidi = run_cli(&server_a, &["bolt12-receive", desc_with_bidi]);
 	let raw_bidi =
 		run_cli_raw(&server_a, &["decode-offer", output_bidi["offer"].as_str().unwrap()]);
+	// LDK exposes offer descriptions through PrintableString, which may replace
+	// control characters before the CLI sanitizer sees them.
 	assert!(
 		!raw_bidi.contains('\u{202E}'),
 		"Raw CLI output must not contain bidi override characters"
 	);
-	assert!(raw_bidi.contains("\\u202E"), "Bidi characters should be escaped as \\uXXXX in output");
 }
 
 #[tokio::test]

--- a/ldk-server-grpc/build.rs
+++ b/ldk-server-grpc/build.rs
@@ -47,10 +47,6 @@ fn generate_protos() {
 			"#[cfg_attr(feature = \"serde\", serde(serialize_with = \"crate::serde_utils::serialize_opt_bytes_hex\"))]",
 		)
 		.field_attribute(
-			"types.Bolt11Jit.secret",
-			"#[cfg_attr(feature = \"serde\", serde(serialize_with = \"crate::serde_utils::serialize_opt_bytes_hex\"))]",
-		)
-		.field_attribute(
 			"types.Bolt12Offer.secret",
 			"#[cfg_attr(feature = \"serde\", serde(serialize_with = \"crate::serde_utils::serialize_opt_bytes_hex\"))]",
 		)

--- a/ldk-server-grpc/src/proto/types.proto
+++ b/ldk-server-grpc/src/proto/types.proto
@@ -33,10 +33,9 @@ message PaymentKind {
   oneof kind {
     Onchain onchain = 1;
     Bolt11 bolt11 = 2;
-    Bolt11Jit bolt11_jit = 3;
-    Bolt12Offer bolt12_offer = 4;
-    Bolt12Refund bolt12_refund = 5;
-    Spontaneous spontaneous = 6;
+    Bolt12Offer bolt12_offer = 3;
+    Bolt12Refund bolt12_refund = 4;
+    Spontaneous spontaneous = 5;
   }
 }
 
@@ -81,32 +80,15 @@ message Bolt11 {
 
   // The secret used by the payment.
   optional bytes secret = 3;
-}
-
-// Represents a BOLT 11 payment intended to open an LSPS 2 just-in-time channel.
-message Bolt11Jit {
-  // The payment hash, i.e., the hash of the preimage.
-  string hash = 1;
-
-  // The pre-image used by the payment.
-  optional string preimage = 2;
-
-  // The secret used by the payment.
-  optional bytes secret = 3;
-
-  // Limits applying to how much fee we allow an LSP to deduct from the payment amount.
-  //
-  // Allowing them to deduct this fee from the first inbound payment will pay for the LSP’s channel opening fees.
-  //
-  // See [`LdkChannelConfig::accept_underpaying_htlcs`](https://docs.rs/lightning/latest/lightning/util/config/struct.ChannelConfig.html#structfield.accept_underpaying_htlcs)
-  // for more information.
-  LSPFeeLimits lsp_fee_limits = 4;
 
   // The value, in thousands of a satoshi, that was deducted from this payment as an extra
   // fee taken by our channel counterparty.
   //
-  // Will only be `Some` once we received the payment.
-  optional uint64 counterparty_skimmed_fee_msat = 5;
+  // Will only ever be `Some` for inbound payments received via an [bLIP-52 / LSPS 2]
+  // just-in-time channel, and only after the payment is observed; `None` otherwise.
+  //
+  // [bLIP-52 / LSPS 2]: https://github.com/lightning/blips/blob/master/blip-0052.md 
+  optional uint64 counterparty_skimmed_fee_msat = 4;
 }
 
 // Represents a BOLT 12 ‘offer’ payment, i.e., a payment for an Offer.
@@ -219,29 +201,29 @@ enum Network {
   REGTEST = 4;
 }
 
+// Identifies the channel and counterparty that an HTLC was processed with.
+message HtlcLocator {
+  // The channel that the HTLC was sent or received on.
+  string channel_id = 1;
+
+  // The `user_channel_id` for the channel.
+  // This can be unset for older serialized events or if the payment was settled on-chain.
+  optional string user_channel_id = 2;
+
+  // The node id of the counterparty for this HTLC.
+  // This can be unset for older serialized events.
+  optional string node_id = 3;
+}
+
 // A forwarded payment through our node.
+//
+// A forwarded payment can involve multiple incoming and outgoing HTLCs, e.g. when acting as a
+// trampoline router. The `prev_htlcs` and `next_htlcs` fields are the canonical representation of
+// the HTLCs associated with this forwarding event. Their indices do not imply pairwise
+// correspondence.
+//
 // See more: https://docs.rs/ldk-node/latest/ldk_node/enum.Event.html#variant.PaymentForwarded
 message ForwardedPayment{
-  // The channel id of the incoming channel between the previous node and us.
-  string prev_channel_id = 1;
-
-  // The channel id of the outgoing channel between the next node and us.
-  string next_channel_id = 2;
-
-  // The `user_channel_id` of the incoming channel between the previous node and us.
-  string prev_user_channel_id = 3;
-
-  // The node id of the previous node.
-  string prev_node_id = 9;
-
-  // The node id of the next node.
-  string next_node_id = 10;
-
-  // The `user_channel_id` of the outgoing channel between the next node and us.
-  // This will be `None` if the payment was settled via an on-chain transaction.
-  // See the caveat described for the `total_fee_earned_msat` field.
-  optional string next_user_channel_id = 4;
-
   // The total fee, in milli-satoshis, which was earned as a result of the payment.
   //
   // Note that if we force-closed the channel over which we forwarded an HTLC while the HTLC was pending, the amount the
@@ -251,22 +233,30 @@ message ForwardedPayment{
   //
   // If the channel which sent us the payment has been force-closed, we will claim the funds via an on-chain transaction.
   // In that case we do not yet know the on-chain transaction fees which we will spend and will instead set this to `None`.
-  optional uint64 total_fee_earned_msat = 5;
+  optional uint64 total_fee_earned_msat = 1;
 
   // The share of the total fee, in milli-satoshis, which was withheld in addition to the forwarding fee.
   // This will only be set if we forwarded an intercepted HTLC with less than the expected amount. This means our
   // counterparty accepted to receive less than the invoice amount.
   //
   // The caveat described above the `total_fee_earned_msat` field applies here as well.
-  optional uint64 skimmed_fee_msat = 6;
+  optional uint64 skimmed_fee_msat = 2;
 
   // If this is true, the forwarded HTLC was claimed by our counterparty via an on-chain transaction.
-  bool claim_from_onchain_tx = 7;
+  bool claim_from_onchain_tx = 3;
 
   // The final amount forwarded, in milli-satoshis, after the fee is deducted.
   //
   // The caveat described above the `total_fee_earned_msat` field applies here as well.
-  optional uint64 outbound_amount_forwarded_msat = 8;
+  optional uint64 outbound_amount_forwarded_msat = 4;
+
+  // The set of incoming HTLCs forwarded to our node that will be claimed by this forward.
+  // This is the canonical incoming HTLC representation.
+  repeated HtlcLocator prev_htlcs = 5;
+
+  // The set of outgoing HTLCs forwarded by our node that have been claimed by this forward.
+  // This is the canonical outgoing HTLC representation.
+  repeated HtlcLocator next_htlcs = 6;
 
 }
 

--- a/ldk-server-grpc/src/types.rs
+++ b/ldk-server-grpc/src/types.rs
@@ -54,7 +54,7 @@ pub struct Payment {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct PaymentKind {
-	#[prost(oneof = "payment_kind::Kind", tags = "1, 2, 3, 4, 5, 6")]
+	#[prost(oneof = "payment_kind::Kind", tags = "1, 2, 3, 4, 5")]
 	pub kind: ::core::option::Option<payment_kind::Kind>,
 }
 /// Nested message and enum types in `PaymentKind`.
@@ -69,12 +69,10 @@ pub mod payment_kind {
 		#[prost(message, tag = "2")]
 		Bolt11(super::Bolt11),
 		#[prost(message, tag = "3")]
-		Bolt11Jit(super::Bolt11Jit),
-		#[prost(message, tag = "4")]
 		Bolt12Offer(super::Bolt12Offer),
-		#[prost(message, tag = "5")]
+		#[prost(message, tag = "4")]
 		Bolt12Refund(super::Bolt12Refund),
-		#[prost(message, tag = "6")]
+		#[prost(message, tag = "5")]
 		Spontaneous(super::Spontaneous),
 	}
 }
@@ -158,40 +156,14 @@ pub struct Bolt11 {
 		serde(serialize_with = "crate::serde_utils::serialize_opt_bytes_hex")
 	)]
 	pub secret: ::core::option::Option<::prost::bytes::Bytes>,
-}
-/// Represents a BOLT 11 payment intended to open an LSPS 2 just-in-time channel.
-#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
-#[cfg_attr(feature = "serde", serde(default))]
-#[allow(clippy::derive_partial_eq_without_eq)]
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct Bolt11Jit {
-	/// The payment hash, i.e., the hash of the preimage.
-	#[prost(string, tag = "1")]
-	pub hash: ::prost::alloc::string::String,
-	/// The pre-image used by the payment.
-	#[prost(string, optional, tag = "2")]
-	pub preimage: ::core::option::Option<::prost::alloc::string::String>,
-	/// The secret used by the payment.
-	#[prost(bytes = "bytes", optional, tag = "3")]
-	#[cfg_attr(
-		feature = "serde",
-		serde(serialize_with = "crate::serde_utils::serialize_opt_bytes_hex")
-	)]
-	pub secret: ::core::option::Option<::prost::bytes::Bytes>,
-	/// Limits applying to how much fee we allow an LSP to deduct from the payment amount.
-	///
-	/// Allowing them to deduct this fee from the first inbound payment will pay for the LSP’s channel opening fees.
-	///
-	/// See \[`LdkChannelConfig::accept_underpaying_htlcs`\](<https://docs.rs/lightning/latest/lightning/util/config/struct.ChannelConfig.html#structfield.accept_underpaying_htlcs>)
-	/// for more information.
-	#[prost(message, optional, tag = "4")]
-	pub lsp_fee_limits: ::core::option::Option<LspFeeLimits>,
 	/// The value, in thousands of a satoshi, that was deducted from this payment as an extra
 	/// fee taken by our channel counterparty.
 	///
-	/// Will only be `Some` once we received the payment.
-	#[prost(uint64, optional, tag = "5")]
+	/// Will only ever be `Some` for inbound payments received via an [bLIP-52 / LSPS 2]
+	/// just-in-time channel, and only after the payment is observed; `None` otherwise.
+	///
+	/// [bLIP-52 / LSPS 2]: <https://github.com/lightning/blips/blob/master/blip-0052.md>
+	#[prost(uint64, optional, tag = "4")]
 	pub counterparty_skimmed_fee_msat: ::core::option::Option<u64>,
 }
 /// Represents a BOLT 12 ‘offer’ payment, i.e., a payment for an Offer.
@@ -292,7 +264,32 @@ pub struct LspFeeLimits {
 	#[prost(uint64, optional, tag = "2")]
 	pub max_proportional_opening_fee_ppm_msat: ::core::option::Option<u64>,
 }
+/// Identifies the channel and counterparty that an HTLC was processed with.
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
+#[cfg_attr(feature = "serde", serde(default))]
+#[allow(clippy::derive_partial_eq_without_eq)]
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct HtlcLocator {
+	/// The channel that the HTLC was sent or received on.
+	#[prost(string, tag = "1")]
+	pub channel_id: ::prost::alloc::string::String,
+	/// The `user_channel_id` for the channel.
+	/// This can be unset for older serialized events or if the payment was settled on-chain.
+	#[prost(string, optional, tag = "2")]
+	pub user_channel_id: ::core::option::Option<::prost::alloc::string::String>,
+	/// The node id of the counterparty for this HTLC.
+	/// This can be unset for older serialized events.
+	#[prost(string, optional, tag = "3")]
+	pub node_id: ::core::option::Option<::prost::alloc::string::String>,
+}
 /// A forwarded payment through our node.
+///
+/// A forwarded payment can involve multiple incoming and outgoing HTLCs, e.g. when acting as a
+/// trampoline router. The `prev_htlcs` and `next_htlcs` fields are the canonical representation of
+/// the HTLCs associated with this forwarding event. Their indices do not imply pairwise
+/// correspondence.
+///
 /// See more: <https://docs.rs/ldk-node/latest/ldk_node/enum.Event.html#variant.PaymentForwarded>
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]
@@ -300,26 +297,6 @@ pub struct LspFeeLimits {
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ForwardedPayment {
-	/// The channel id of the incoming channel between the previous node and us.
-	#[prost(string, tag = "1")]
-	pub prev_channel_id: ::prost::alloc::string::String,
-	/// The channel id of the outgoing channel between the next node and us.
-	#[prost(string, tag = "2")]
-	pub next_channel_id: ::prost::alloc::string::String,
-	/// The `user_channel_id` of the incoming channel between the previous node and us.
-	#[prost(string, tag = "3")]
-	pub prev_user_channel_id: ::prost::alloc::string::String,
-	/// The node id of the previous node.
-	#[prost(string, tag = "9")]
-	pub prev_node_id: ::prost::alloc::string::String,
-	/// The node id of the next node.
-	#[prost(string, tag = "10")]
-	pub next_node_id: ::prost::alloc::string::String,
-	/// The `user_channel_id` of the outgoing channel between the next node and us.
-	/// This will be `None` if the payment was settled via an on-chain transaction.
-	/// See the caveat described for the `total_fee_earned_msat` field.
-	#[prost(string, optional, tag = "4")]
-	pub next_user_channel_id: ::core::option::Option<::prost::alloc::string::String>,
 	/// The total fee, in milli-satoshis, which was earned as a result of the payment.
 	///
 	/// Note that if we force-closed the channel over which we forwarded an HTLC while the HTLC was pending, the amount the
@@ -329,23 +306,31 @@ pub struct ForwardedPayment {
 	///
 	/// If the channel which sent us the payment has been force-closed, we will claim the funds via an on-chain transaction.
 	/// In that case we do not yet know the on-chain transaction fees which we will spend and will instead set this to `None`.
-	#[prost(uint64, optional, tag = "5")]
+	#[prost(uint64, optional, tag = "1")]
 	pub total_fee_earned_msat: ::core::option::Option<u64>,
 	/// The share of the total fee, in milli-satoshis, which was withheld in addition to the forwarding fee.
 	/// This will only be set if we forwarded an intercepted HTLC with less than the expected amount. This means our
 	/// counterparty accepted to receive less than the invoice amount.
 	///
 	/// The caveat described above the `total_fee_earned_msat` field applies here as well.
-	#[prost(uint64, optional, tag = "6")]
+	#[prost(uint64, optional, tag = "2")]
 	pub skimmed_fee_msat: ::core::option::Option<u64>,
 	/// If this is true, the forwarded HTLC was claimed by our counterparty via an on-chain transaction.
-	#[prost(bool, tag = "7")]
+	#[prost(bool, tag = "3")]
 	pub claim_from_onchain_tx: bool,
 	/// The final amount forwarded, in milli-satoshis, after the fee is deducted.
 	///
 	/// The caveat described above the `total_fee_earned_msat` field applies here as well.
-	#[prost(uint64, optional, tag = "8")]
+	#[prost(uint64, optional, tag = "4")]
 	pub outbound_amount_forwarded_msat: ::core::option::Option<u64>,
+	/// The set of incoming HTLCs forwarded to our node that will be claimed by this forward.
+	/// This is the canonical incoming HTLC representation.
+	#[prost(message, repeated, tag = "5")]
+	pub prev_htlcs: ::prost::alloc::vec::Vec<HtlcLocator>,
+	/// The set of outgoing HTLCs forwarded by our node that have been claimed by this forward.
+	/// This is the canonical outgoing HTLC representation.
+	#[prost(message, repeated, tag = "6")]
+	pub next_htlcs: ::prost::alloc::vec::Vec<HtlcLocator>,
 }
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "serde", serde(rename_all = "snake_case"))]

--- a/ldk-server/Cargo.toml
+++ b/ldk-server/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["bitcoin", "lightning", "ldk", "server"]
 categories = ["cryptography::cryptocurrencies"]
 
 [dependencies]
-ldk-node = { git = "https://github.com/lightningdevkit/ldk-node", rev = "16eaa6f46308965f501904506be3ceecd293f358" }
+ldk-node = { git = "https://github.com/lightningdevkit/ldk-node", rev = "00dba456a10cb60172eaa74e0a8b11c5e0473dcc" }
 serde = { version = "1.0.203", default-features = false, features = ["derive"] }
 hyper = { version = "1", default-features = false, features = ["server", "http2"] }
 http-body-util = { version = "0.1", default-features = false }

--- a/ldk-server/src/main.rs
+++ b/ldk-server/src/main.rs
@@ -29,11 +29,10 @@ use ldk_node::config::Config;
 use ldk_node::lightning::events::ClosureReason;
 use ldk_node::lightning::ln::channelmanager::PaymentId;
 use ldk_node::lightning::ln::types::ChannelId;
-use ldk_node::CustomTlvRecord;
-use ldk_node::{Builder, Event, Node};
+use ldk_node::{Builder, CustomTlvRecord, Event, Node};
 use ldk_server_grpc::events;
 use ldk_server_grpc::events::{event_envelope, EventEnvelope};
-use ldk_server_grpc::types::Payment;
+use ldk_server_grpc::types::{HtlcLocator, Payment};
 use log::{debug, error, info};
 use prost::Message;
 use tokio::net::TcpListener;
@@ -526,29 +525,41 @@ fn main() {
 							);
 						},
 						Event::PaymentForwarded {
-							prev_channel_id,
-							next_channel_id,
-							prev_user_channel_id,
-							next_user_channel_id,
-							prev_node_id,
-							next_node_id,
+							prev_htlcs,
+							next_htlcs,
 							total_fee_earned_msat,
 							skimmed_fee_msat,
 							claim_from_onchain_tx,
 							outbound_amount_forwarded_msat
 						} => {
-
-							info!("PAYMENT_FORWARDED: with outbound_amount_forwarded_msat {}, total_fee_earned_msat: {}, inbound channel: {}, outbound channel: {}",
-								outbound_amount_forwarded_msat.unwrap_or(0), total_fee_earned_msat.unwrap_or(0), prev_channel_id, next_channel_id
+							info!(
+								"PAYMENT_FORWARDED: outbound_amount_forwarded_msat {}, total_fee_earned_msat: {}, inbound HTLCs: {}, outbound HTLCs: {}",
+								outbound_amount_forwarded_msat.unwrap_or(0),
+								total_fee_earned_msat.unwrap_or(0),
+								prev_htlcs.len(),
+								next_htlcs.len(),
 							);
 
+							let prev_htlcs = prev_htlcs
+								.into_iter()
+								.map(|htlc| HtlcLocator {
+									channel_id: htlc.channel_id.to_string(),
+									user_channel_id: htlc.user_channel_id.map(|u| u.0.to_string()),
+									node_id: htlc.node_id.map(|n| n.to_string()),
+								})
+								.collect();
+							let next_htlcs = next_htlcs
+								.into_iter()
+								.map(|htlc| HtlcLocator {
+									channel_id: htlc.channel_id.to_string(),
+									user_channel_id: htlc.user_channel_id.map(|u| u.0.to_string()),
+									node_id: htlc.node_id.map(|n| n.to_string()),
+								})
+								.collect();
+
 							let forwarded_payment = forwarded_payment_to_proto(
-								prev_channel_id,
-								next_channel_id,
-								prev_user_channel_id,
-								next_user_channel_id,
-								prev_node_id,
-								next_node_id,
+								prev_htlcs,
+								next_htlcs,
 								total_fee_earned_msat,
 								skimmed_fee_msat,
 								claim_from_onchain_tx,

--- a/ldk-server/src/util/entropy.rs
+++ b/ldk-server/src/util/entropy.rs
@@ -7,10 +7,9 @@
 // You may not use this file except in accordance with one or both of these
 // licenses.
 
-use std::fs;
-use std::io;
 use std::path::Path;
 use std::str::FromStr;
+use std::{fs, io};
 
 use ldk_node::bip39::Mnemonic;
 use ldk_node::entropy::{generate_entropy_mnemonic, NodeEntropy};
@@ -49,9 +48,10 @@ pub(crate) fn load_or_generate_node_entropy(storage_dir: &Path) -> io::Result<No
 
 #[cfg(test)]
 mod tests {
-	use super::*;
 	use std::os::unix::fs::{MetadataExt, PermissionsExt};
 	use std::path::PathBuf;
+
+	use super::*;
 
 	const STALE_SEED_FILE: &str = "keys_seed";
 	const KNOWN_MNEMONIC: &str = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon art";

--- a/ldk-server/src/util/proto_adapter.rs
+++ b/ldk-server/src/util/proto_adapter.rs
@@ -10,11 +10,9 @@
 use bytes::Bytes;
 use hex::prelude::*;
 use ldk_node::bitcoin::hashes::sha256;
-use ldk_node::bitcoin::secp256k1::PublicKey;
 use ldk_node::bitcoin::Network;
 use ldk_node::config::{ChannelConfig, MaxDustHTLCExposure};
 use ldk_node::lightning::chain::channelmonitor::BalanceSource;
-use ldk_node::lightning::ln::types::ChannelId;
 use ldk_node::lightning::routing::gossip::{
 	ChannelInfo, ChannelUpdateInfo, NodeAnnouncementInfo, NodeInfo, RoutingFees,
 };
@@ -22,20 +20,20 @@ use ldk_node::lightning_invoice::{Bolt11InvoiceDescription, Description, Sha256}
 use ldk_node::payment::{
 	ConfirmationStatus, PaymentDetails, PaymentDirection, PaymentKind, PaymentStatus,
 };
-use ldk_node::{ChannelDetails, LightningBalance, PeerDetails, PendingSweepBalance, UserChannelId};
+use ldk_node::{ChannelDetails, LightningBalance, PeerDetails, PendingSweepBalance};
 use ldk_server_grpc::types::confirmation_status::Status::{Confirmed, Unconfirmed};
 use ldk_server_grpc::types::lightning_balance::BalanceType::{
 	ClaimableAwaitingConfirmations, ClaimableOnChannelClose, ContentiousClaimable,
 	CounterpartyRevokedOutputClaimable, MaybePreimageClaimableHtlc, MaybeTimeoutClaimableHtlc,
 };
 use ldk_server_grpc::types::payment_kind::Kind::{
-	Bolt11, Bolt11Jit, Bolt12Offer, Bolt12Refund, Onchain, Spontaneous,
+	Bolt11, Bolt12Offer, Bolt12Refund, Onchain, Spontaneous,
 };
 use ldk_server_grpc::types::pending_sweep_balance::BalanceType::{
 	AwaitingThresholdConfirmations, BroadcastAwaitingConfirmation, PendingBroadcast,
 };
 use ldk_server_grpc::types::{
-	bolt11_invoice_description, Channel, ForwardedPayment, LspFeeLimits, OutPoint, Payment, Peer,
+	bolt11_invoice_description, Channel, ForwardedPayment, HtlcLocator, OutPoint, Payment, Peer,
 };
 
 use crate::api::error::LdkServerError;
@@ -154,31 +152,15 @@ pub(crate) fn payment_kind_to_proto(
 				status: Some(confirmation_status_to_proto(status)),
 			})),
 		},
-		PaymentKind::Bolt11 { hash, preimage, secret } => ldk_server_grpc::types::PaymentKind {
-			kind: Some(Bolt11(ldk_server_grpc::types::Bolt11 {
-				hash: hash.to_string(),
-				preimage: preimage.map(|p| p.to_string()),
-				secret: secret.map(|s| Bytes::copy_from_slice(&s.0)),
-			})),
-		},
-		PaymentKind::Bolt11Jit {
-			hash,
-			preimage,
-			secret,
-			lsp_fee_limits,
-			counterparty_skimmed_fee_msat,
-		} => ldk_server_grpc::types::PaymentKind {
-			kind: Some(Bolt11Jit(ldk_server_grpc::types::Bolt11Jit {
-				hash: hash.to_string(),
-				preimage: preimage.map(|p| p.to_string()),
-				secret: secret.map(|s| Bytes::copy_from_slice(&s.0)),
-				lsp_fee_limits: Some(LspFeeLimits {
-					max_total_opening_fee_msat: lsp_fee_limits.max_total_opening_fee_msat,
-					max_proportional_opening_fee_ppm_msat: lsp_fee_limits
-						.max_proportional_opening_fee_ppm_msat,
-				}),
-				counterparty_skimmed_fee_msat,
-			})),
+		PaymentKind::Bolt11 { hash, preimage, secret, counterparty_skimmed_fee_msat } => {
+			ldk_server_grpc::types::PaymentKind {
+				kind: Some(Bolt11(ldk_server_grpc::types::Bolt11 {
+					hash: hash.to_string(),
+					preimage: preimage.map(|p| p.to_string()),
+					secret: secret.map(|s| Bytes::copy_from_slice(&s.0)),
+					counterparty_skimmed_fee_msat,
+				})),
+			}
 		},
 		PaymentKind::Bolt12Offer { hash, preimage, secret, offer_id, payer_note, quantity } => {
 			ldk_server_grpc::types::PaymentKind {
@@ -404,28 +386,18 @@ pub(crate) fn pending_sweep_balance_to_proto(
 	}
 }
 
-#[allow(clippy::too_many_arguments)]
 pub(crate) fn forwarded_payment_to_proto(
-	prev_channel_id: ChannelId, next_channel_id: ChannelId,
-	prev_user_channel_id: Option<UserChannelId>, next_user_channel_id: Option<UserChannelId>,
-	prev_node_id: Option<PublicKey>, next_node_id: Option<PublicKey>,
-	total_fee_earned_msat: Option<u64>, skimmed_fee_msat: Option<u64>, claim_from_onchain_tx: bool,
+	prev_htlcs: Vec<HtlcLocator>, next_htlcs: Vec<HtlcLocator>, total_fee_earned_msat: Option<u64>,
+	skimmed_fee_msat: Option<u64>, claim_from_onchain_tx: bool,
 	outbound_amount_forwarded_msat: Option<u64>,
 ) -> ForwardedPayment {
 	ForwardedPayment {
-		prev_channel_id: prev_channel_id.to_string(),
-		next_channel_id: next_channel_id.to_string(),
-		prev_user_channel_id: prev_user_channel_id
-			.expect("prev_user_channel_id expected for ldk-server >=0.1")
-			.0
-			.to_string(),
-		next_user_channel_id: next_user_channel_id.map(|u| u.0.to_string()),
-		prev_node_id: prev_node_id.expect("prev_node_id expected for ldk-server >=0.1").to_string(),
-		next_node_id: next_node_id.expect("next_node_id expected for ldk-node >=0.1").to_string(),
 		total_fee_earned_msat,
 		skimmed_fee_msat,
 		claim_from_onchain_tx,
 		outbound_amount_forwarded_msat,
+		prev_htlcs,
+		next_htlcs,
 	}
 }
 

--- a/ldk-server/src/util/tls.rs
+++ b/ldk-server/src/util/tls.rs
@@ -14,6 +14,7 @@ use std::path::Path;
 use base64::Engine;
 use ring::rand::SystemRandom;
 use ring::signature::{EcdsaKeyPair, KeyPair, ECDSA_P256_SHA256_ASN1_SIGNING};
+use tokio_rustls::rustls::crypto::ring::default_provider;
 use tokio_rustls::rustls::pki_types::{CertificateDer, PrivateKeyDer};
 use tokio_rustls::rustls::ServerConfig;
 
@@ -409,7 +410,9 @@ fn load_tls_config(cert_path: &str, key_path: &str) -> Result<ServerConfig, Stri
 
 	let key = parse_pem_private_key(&key_pem)?;
 
-	let mut config = ServerConfig::builder()
+	let mut config = ServerConfig::builder_with_provider(default_provider().into())
+		.with_safe_default_protocol_versions()
+		.map_err(|e| format!("Failed to set TLS protocol versions: {e}"))?
 		.with_no_client_auth()
 		.with_single_cert(certs, key)
 		.map_err(|e| format!("Failed to build TLS server config: {e}"))?;


### PR DESCRIPTION
## What this PR does:

Bumps the `ldk-node` dependency to revision [47dad6d](https://github.com/lightningdevkit/ldk-node/commit/47dad6d909af0fbb53e76d07740c04df5abdde3b), which, among other changes, contains the prerequisite for exposing `NodeFeatures` to `ldk-server` callers via the node `status` endpoint. We need this for callers interested in querying the features supported by the node. 

Notable upstream changes adapted here
- `Bolt11Jit` merged into Bolt11: ldk-node folded the JIT payment variant into `Bolt11`, adding a `counterparty_skimmed_fee_msat` field. The `Bolt11Jit` proto message, its serde attribute in `build.rs`, and the corresponding proto_adapter arm are all removed. The original proto tag numbers for Bolt12Offer (4), Bolt12Refund (5), and Spontaneous (6) are preserved — tag 3 is reserved to avoid wire-compatibility issues with previously-serialized `Bolt11Jit` data.

- `PaymentForwarded` event restructured around `HTLCLocator`: The six flat channel/node/user-channel-id fields are replaced by `prev_htlcs` and `next_htlcs` (`Vec<HTLCLocator>`), supporting multi-HTLC forwards. The legacy scalar fields are retained in the proto as deprecated, populated from the first element of each vec for backward compatibility (not sure if this is the correct way to handle this).