### PR TITLE
Test all features in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
         if: matrix.msrv
         run: cargo clippy --all-features -- -D warnings
       - name: Test on Rust ${{ matrix.toolchain }}
-        run: cargo test
+        run: cargo test --all-features
       - name: Cargo check release on Rust ${{ matrix.toolchain }}
         run: cargo check --release
       - name: Cargo check doc on Rust ${{ matrix.toolchain }}

--- a/ldk-server/src/util/config.rs
+++ b/ldk-server/src/util/config.rs
@@ -1347,8 +1347,22 @@ mod tests {
 
 		#[cfg(feature = "experimental-lsps2-support")]
 		{
-			validate_missing!(
-				"[liquidity.lsps2_service]",
+			let toml_config = r#"
+				[node]
+				network = "regtest"
+
+				[bitcoind]
+				rpc_address = "127.0.0.1:8332"
+				rpc_user = "bitcoind-testuser"
+				rpc_password = "bitcoind-testpassword"
+			"#;
+			fs::write(storage_path.join(config_file_name), &toml_config).unwrap();
+			let result = load_config(&args_config);
+			assert!(result.is_err());
+			let err = result.unwrap_err();
+			assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+			assert_eq!(
+				err.to_string(),
 				"`liquidity.lsps2_service` must be defined in config if enabling `experimental-lsps2-support` feature."
 			);
 		}


### PR DESCRIPTION
We weren't running our tests with all features on CI. This left one test to be left out and did not pass. Fixes the test by removing the whole LSPS2 config section instead of just the header and enables --all-features for our CI tests.