### PR TITLE
grpc: add claim_deadline to PaymentClaimable event

### DIFF
--- a/e2e-tests/tests/e2e.rs
+++ b/e2e-tests/tests/e2e.rs
@@ -1262,7 +1262,10 @@ async fn test_hodl_invoice_claim() {
 		// Wait for PaymentClaimable event on B (drain other events)
 		let claimable =
 			wait_for_event(&mut events_b, |e| matches!(e, Event::PaymentClaimable(_))).await;
-		assert!(matches!(&claimable.event, Some(Event::PaymentClaimable(_))));
+		assert!(matches!(
+			&claimable.event,
+			Some(Event::PaymentClaimable(event)) if event.claim_deadline.is_some()
+		));
 
 		// Claim the payment on B
 		let mut args: Vec<&str> = vec!["bolt11-claim-for-hash", &preimage_hex];

--- a/ldk-server-grpc/src/events.rs
+++ b/ldk-server-grpc/src/events.rs
@@ -190,6 +190,9 @@ pub struct PaymentClaimable {
 	/// Custom TLV records attached to the claimable payment, if any.
 	#[prost(message, repeated, tag = "2")]
 	pub custom_records: ::prost::alloc::vec::Vec<super::types::CustomTlvRecord>,
+	/// The block height by which this payment must be claimed before it is failed back.
+	#[prost(uint32, optional, tag = "3")]
+	pub claim_deadline: ::core::option::Option<u32>,
 }
 /// PaymentForwarded indicates a payment was forwarded through the node.
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]

--- a/ldk-server-grpc/src/proto/events.proto
+++ b/ldk-server-grpc/src/proto/events.proto
@@ -119,6 +119,8 @@ message PaymentClaimable {
   types.Payment payment = 1;
   // Custom TLV records attached to the claimable payment, if any.
   repeated types.CustomTlvRecord custom_records = 2;
+  // The block height by which this payment must be claimed before it is failed back.
+  optional uint32 claim_deadline = 3;
 }
 
 // PaymentForwarded indicates a payment was forwarded through the node.

--- a/ldk-server/src/main.rs
+++ b/ldk-server/src/main.rs
@@ -511,12 +511,12 @@ fn main() {
 								metrics.update_payments_count(false);
 							}
 						},
-						Event::PaymentClaimable { payment_id, custom_records, .. } => {
+						Event::PaymentClaimable { payment_id, custom_records, claim_deadline, .. } => {
 							send_event_and_upsert_payment(
 								&payment_id,
 								|payment_ref| {
 									event_envelope::Event::PaymentClaimable(
-										build_payment_claimable_proto(payment_ref, &custom_records),
+										build_payment_claimable_proto(payment_ref, &custom_records, claim_deadline),
 									)
 								},
 								&event_node,
@@ -872,13 +872,14 @@ fn load_or_generate_api_key(storage_dir: &Path) -> std::io::Result<String> {
 }
 
 fn build_payment_claimable_proto(
-	payment_ref: &Payment, custom_records: &[CustomTlvRecord],
+	payment_ref: &Payment, custom_records: &[CustomTlvRecord], claim_deadline: Option<u32>,
 ) -> events::PaymentClaimable {
 	let proto_custom_records: Vec<_> =
 		custom_records.iter().map(node_to_proto_custom_tlv).collect();
 	events::PaymentClaimable {
 		payment: Some(payment_ref.clone()),
 		custom_records: proto_custom_records,
+		claim_deadline,
 	}
 }
 


### PR DESCRIPTION
add claim_deadline to PaymentClaimable event, so that it's easier to determine how much time we have for security in some out-of-lightning protocol using hodl invoices.