### PR TITLE
Fix compile issue in test

### DIFF
--- a/ldk-server/src/main.rs
+++ b/ldk-server/src/main.rs
@@ -991,7 +991,7 @@ mod tests {
 			CustomTlvRecord { type_num: 65537, value: vec![1, 2, 3] },
 			CustomTlvRecord { type_num: 65538, value: Vec::new() },
 		];
-		let proto = build_payment_claimable_proto(&payment, &records);
+		let proto = build_payment_claimable_proto(&payment, &records, None);
 		assert_eq!(proto.custom_records.len(), 2);
 		assert_eq!(proto.custom_records[0].type_num, 65537);
 		assert_eq!(proto.custom_records[0].value.to_vec(), vec![1, 2, 3]);


### PR DESCRIPTION
In c3051b0ce3a7d40f3bf64cd7d1dceab22263b688 this was introduced. I thought I ran full CI locally before merging but maybe only ran e2e tests and not the ldk-server unit tests. This fixes the small compile issue.