### PR TITLE
Expose Postgres storage backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,6 +360,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -496,10 +505,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "displaydoc"
@@ -593,6 +642,12 @@ dependencies = [
 
 [[package]]
 name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
+name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
@@ -626,6 +681,21 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -732,6 +802,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -740,7 +820,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -868,6 +948,15 @@ name = "hex_lit"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "home"
@@ -1297,12 +1386,15 @@ dependencies = [
  "lightning-transaction-sync",
  "lightning-types",
  "log",
+ "native-tls",
+ "postgres-native-tls",
  "prost",
  "rusqlite",
  "rustls 0.23.42",
  "serde",
  "serde_json",
  "tokio",
+ "tokio-postgres",
  "vss-client-ng",
  "winapi",
 ]
@@ -1405,6 +1497,15 @@ name = "libm"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+
+[[package]]
+name = "libredox"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "libsqlite3-sys"
@@ -1580,6 +1681,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1596,6 +1706,16 @@ name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
 
 [[package]]
 name = "memchr"
@@ -1627,7 +1747,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
 
@@ -1636,6 +1756,23 @@ name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
 
 [[package]]
 name = "num-traits"
@@ -1651,6 +1788,72 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "openssl"
+version = "0.10.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -1672,6 +1875,25 @@ checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
  "indexmap 2.12.0",
+]
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_shared",
+ "serde",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -1718,6 +1940,47 @@ version = "0.2.0"
 source = "git+https://github.com/lightningdevkit/rust-lightning?rev=506cb91f2e0fb87906188b79777bcf42595d3623#506cb91f2e0fb87906188b79777bcf42595d3623"
 dependencies = [
  "getrandom 0.2.16",
+]
+
+[[package]]
+name = "postgres-native-tls"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fef4de47bb81477e0c3deaf153a1b10ae176484713ff1640969f4cb96b653ebc"
+dependencies = [
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-postgres",
+]
+
+[[package]]
+name = "postgres-protocol"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ee9dd5fe15055d2b6806f4736aa0c9637217074e224bbec46d4041b91bb9491"
+dependencies = [
+ "base64 0.22.1",
+ "byteorder",
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "hmac",
+ "md-5",
+ "memchr",
+ "rand 0.9.2",
+ "sha2",
+ "stringprep",
+]
+
+[[package]]
+name = "postgres-types"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b858f82211e84682fecd373f68e1ceae642d8d751a1ebd13f33de6257b3e20"
+dependencies = [
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "postgres-protocol",
 ]
 
 [[package]]
@@ -1941,6 +2204,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags 2.10.0",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2069,7 +2341,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
 dependencies = [
  "bitflags 2.10.0",
- "fallible-iterator",
+ "fallible-iterator 0.3.0",
  "fallible-streaming-iterator",
  "hashlink",
  "libsqlite3-sys",
@@ -2190,6 +2462,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "sct"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2218,6 +2505,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d17b898a6d6948c3a8ee4372c17cb384f90d2e6e912ef00895b14fd7ab54ec38"
+dependencies = [
+ "bitflags 2.10.0",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -2285,6 +2595,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2298,6 +2619,12 @@ checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "slab"
@@ -2336,6 +2663,17 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
 
 [[package]]
 name = "strsim"
@@ -2404,7 +2742,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
 
@@ -2511,6 +2849,42 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.108",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-postgres"
+version = "0.7.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcea47c8f71744367793f16c2db1f11cb859d28f436bdb4ca9193eb1f787ee42"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "futures-channel",
+ "futures-util",
+ "log",
+ "parking_lot",
+ "percent-encoding",
+ "phf",
+ "pin-project-lite",
+ "postgres-protocol",
+ "postgres-types",
+ "rand 0.9.2",
+ "socket2 0.6.1",
+ "tokio",
+ "tokio-util",
+ "whoami",
 ]
 
 [[package]]
@@ -2722,6 +3096,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2735,6 +3121,12 @@ checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "untrusted"
@@ -2809,12 +3201,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
 name = "wasip2"
 version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
  "wit-bindgen",
+]
+
+[[package]]
+name = "wasite"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
+dependencies = [
+ "wasi 0.14.7+wasi-0.2.4",
 ]
 
 [[package]]
@@ -2920,6 +3330,17 @@ dependencies = [
  "home",
  "once_cell",
  "rustix 0.38.44",
+]
+
+[[package]]
+name = "whoami"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fae98cf96deed1b7572272dfc777713c249ae40aa1cf8862e091e8b745f5361"
+dependencies = [
+ "libredox",
+ "wasite",
+ "web-sys",
 ]
 
 [[package]]

--- a/contrib/ldk-server-config.toml
+++ b/contrib/ldk-server-config.toml
@@ -28,7 +28,14 @@ alias = "ldk_server"                          # Lightning node alias
 
 # Storage settings
 [storage.disk]
-dir_path = "/tmp/ldk-server/"                 # Path for LDK and BDK data persistence, optional, defaults to ~/Library/Application Support/ldk-server/ on macOS, ~/.ldk-server/ on Linux
+dir_path = "/tmp/ldk-server/"                 # Path for local ldk-server data, optional, defaults to ~/Library/Application Support/ldk-server/ on macOS, ~/.ldk-server/ on Linux
+
+# Optional LDK Node PostgreSQL storage for wallet and channel state.
+#[storage.postgres]
+#connection_string = "postgresql://postgres:postgres@localhost:5432" # PostgreSQL connection string. Do not include dbname if db_name is set.
+#db_name = "ldk_db"                         # Optional database name.
+#kv_table_name = "ldk_data"                 # Optional KV table name.
+#certificate_path = "/path/to/postgres-ca.pem" # Optional CA certificate PEM file for TLS PostgreSQL connections.
 
 [log]
 level = "Debug"                               # Log level (Error, Warn, Info, Debug, Trace)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -100,8 +100,32 @@ cooldown_secs = 3600
 
 ### `[storage.disk]`
 
-Where persistent data is stored. Defaults to `~/.ldk-server/` on Linux and
-`~/Library/Application Support/ldk-server/` on macOS.
+Where local ldk-server data is stored. Defaults to `~/.ldk-server/` on Linux and
+`~/Library/Application Support/ldk-server/` on macOS. This directory is still used for
+the node mnemonic, API key, TLS material, logs, and ldk-server's payment history when
+LDK Node wallet/channel state uses PostgreSQL.
+
+### `[storage.postgres]`
+
+Optional PostgreSQL storage for LDK Node wallet and channel state.
+
+```toml
+[storage.postgres]
+connection_string = "postgresql://postgres:postgres@localhost:5432"
+db_name = "ldk_db"
+kv_table_name = "ldk_data"
+certificate_path = "/path/to/postgres-ca.pem"
+```
+
+Only `connection_string` is required. `db_name`, `kv_table_name`, and `certificate_path`
+are optional. If `db_name` is set, do not also include a database name in the connection
+string. If `certificate_path` is set, the file must contain a PEM-encoded CA certificate
+for TLS PostgreSQL connections.
+
+Storage migration is not supported. ldk-server refuses to start with PostgreSQL when an existing
+`ldk_node_data.sqlite` file is present. After the first successful PostgreSQL node build,
+ldk-server creates `<network_dir>/ldk_node_postgres.lock` and refuses to start with SQLite while
+that file exists.
 
 ### `[log]`
 
@@ -204,6 +228,7 @@ Two resolution methods are supported via the `mode` field:
   <network>/                # e.g., bitcoin/, regtest/, signet/
     api_key                # API key
     ldk-server.log         # Log file
+    ldk_node_postgres.lock  # Present when LDK Node state uses PostgreSQL
     ldk_node_data.sqlite   # LDK Node state (channels, on-chain wallet)
     ldk_server_data.sqlite # Payment and forwarding history
 ```
@@ -212,3 +237,7 @@ The mnemonic is the node's master secret, required to recover on-chain funds. On
 ldk-server generates a fresh 24-word BIP39 mnemonic at `<storage_dir>/keys_mnemonic` if the file
 does not already exist. `ldk_node_data.sqlite` holds channel state, both are required to recover
 channel funds. See [Operations - Backups](operations.md#backups) for backup guidance.
+
+When `[storage.postgres]` is configured, LDK Node wallet/channel state is stored in
+PostgreSQL instead of `ldk_node_data.sqlite`. The storage directory remains required for
+the mnemonic, API key, TLS material, logs, and `ldk_server_data.sqlite`.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -53,7 +53,7 @@ the following config to `/etc/logrotate.d/ldk-server` (adjust the log path to ma
 | File                                   | Priority     | Description                                                                |
 | -------------------------------------- | ------------ | -------------------------------------------------------------------------- |
 | `<storage_dir>/keys_mnemonic`          | **Critical** | BIP39 mnemonic. Required to recover on-chain funds. Default for new installs. |
-| `<network_dir>/ldk_node_data.sqlite`   | **Critical** | Channel state and on-chain wallet data. Required to recover channel funds. |
+| `<network_dir>/ldk_node_data.sqlite` or configured PostgreSQL database | **Critical** | Channel state and on-chain wallet data. Required to recover channel funds. |
 | `<network_dir>/ldk_server_data.sqlite` | Nice-to-have | Payment and forwarding history                                             |
 
 ### What is Reconstructable
@@ -195,9 +195,10 @@ all clients will need the new certificate.
 
 ## Network-Specific Notes
 
-Data is stored in per-network subdirectories (`bitcoin/`, `testnet/`, `signet/`, `regtest/`,
-etc.) under the storage root. This means you can run multiple networks from one storage
-directory without conflicts.
+Local data is stored in per-network subdirectories (`bitcoin/`, `testnet/`, `signet/`,
+`regtest/`, etc.) under the storage root. This means you can run multiple networks from one
+local storage directory without conflicts. PostgreSQL storage is not automatically isolated
+by network; configure a distinct database or table for each network.
 
 The `keys_mnemonic` file is shared across networks (stored at the storage root, not per-network).
 Keys are split by network at the derivation path level, so the same mnemonic will produce

--- a/ldk-server/Cargo.toml
+++ b/ldk-server/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["bitcoin", "lightning", "ldk", "server"]
 categories = ["cryptography::cryptocurrencies"]
 
 [dependencies]
-ldk-node = { git = "https://github.com/lightningdevkit/ldk-node", rev = "056447c28221be02c3d39f8c6ae430a67ebbd850" }
+ldk-node = { git = "https://github.com/lightningdevkit/ldk-node", rev = "056447c28221be02c3d39f8c6ae430a67ebbd850", features = ["postgres"] }
 serde = { version = "1.0.203", default-features = false, features = ["derive"] }
 hyper = { version = "1", default-features = false, features = ["server", "http2"] }
 http-body-util = { version = "0.1", default-features = false }

--- a/ldk-server/src/main.rs
+++ b/ldk-server/src/main.rs
@@ -49,7 +49,7 @@ use crate::io::persist::{
 	PAYMENTS_PERSISTENCE_SECONDARY_NAMESPACE,
 };
 use crate::service::NodeService;
-use crate::util::config::{load_config, ArgsConfig, ChainSource};
+use crate::util::config::{load_config, ArgsConfig, ChainSource, LdkNodeStorageConfig};
 use crate::util::logger::{LogConfig, ServerLogger};
 use crate::util::metrics::Metrics;
 use crate::util::proto_adapter::{forwarded_payment_to_proto, payment_to_proto};
@@ -57,6 +57,7 @@ use crate::util::tls::get_or_generate_tls_config;
 use crate::util::{systemd, write_new};
 
 const API_KEY_FILE: &str = "api_key";
+const LDK_NODE_POSTGRES_LOCK_FILE: &str = "ldk_node_postgres.lock";
 const FULL_VERSION: &str = concat!(env!("CARGO_PKG_VERSION"), " (", env!("GIT_HASH"), ")");
 
 pub fn get_default_data_dir() -> Option<PathBuf> {
@@ -249,6 +250,13 @@ fn main() {
 
 	builder.set_runtime(runtime.handle().clone());
 
+	if let Err(e) =
+		ensure_no_unsupported_storage_migration(&network_dir, &config_file.ldk_node_storage)
+	{
+		error!("{e}");
+		std::process::exit(-1);
+	}
+
 	let node_entropy = match crate::util::entropy::load_or_generate_node_entropy(&storage_dir) {
 		Ok(entropy) => entropy,
 		Err(e) => {
@@ -257,13 +265,22 @@ fn main() {
 		},
 	};
 
-	let node = match builder.build(node_entropy) {
-		Ok(node) => Arc::new(node),
+	let uses_postgres =
+		matches!(config_file.ldk_node_storage, LdkNodeStorageConfig::Postgres { .. });
+	let node = match build_node(builder, node_entropy, config_file.ldk_node_storage) {
+		Ok(node) => node,
 		Err(e) => {
 			error!("Failed to build LDK Node: {e}");
 			std::process::exit(-1);
 		},
 	};
+	if uses_postgres {
+		if let Err(e) = persist_postgres_storage_lock(&network_dir) {
+			error!("{e}");
+			std::process::exit(-1);
+		}
+	}
+	let node = Arc::new(node);
 
 	let paginated_store: Arc<dyn PaginatedKVStore> =
 		Arc::new(match SqliteStore::new(network_dir.clone(), None, None) {
@@ -691,6 +708,69 @@ fn main() {
 	log::logger().flush();
 }
 
+fn ensure_no_unsupported_storage_migration(
+	network_dir: &Path, ldk_node_storage: &LdkNodeStorageConfig,
+) -> Result<(), String> {
+	let sqlite_path = network_dir.join(ldk_node::io::sqlite_store::SQLITE_DB_FILE_NAME);
+	let sqlite_exists = sqlite_path
+		.try_exists()
+		.map_err(|e| format!("Failed to check for existing SQLite LDK Node state: {e}"))?;
+	let postgres_lock_path = network_dir.join(LDK_NODE_POSTGRES_LOCK_FILE);
+	let postgres_lock_exists = postgres_lock_path
+		.try_exists()
+		.map_err(|e| format!("Failed to check for PostgreSQL storage lock: {e}"))?;
+
+	match ldk_node_storage {
+		LdkNodeStorageConfig::Postgres { .. } if sqlite_exists => {
+			return Err(format!(
+				"Refusing to switch LDK Node storage from SQLite to PostgreSQL because {} exists. Storage migration is not supported; remove [storage.postgres] to continue using SQLite.",
+				sqlite_path.display()
+			));
+		},
+		LdkNodeStorageConfig::Sqlite if postgres_lock_exists => {
+			return Err(format!(
+				"Refusing to switch LDK Node storage from PostgreSQL to SQLite because {} exists. Storage migration is not supported; restore [storage.postgres] to continue using PostgreSQL.",
+				postgres_lock_path.display()
+			));
+		},
+		_ => {},
+	}
+
+	Ok(())
+}
+
+fn persist_postgres_storage_lock(network_dir: &Path) -> Result<(), String> {
+	let lock_path = network_dir.join(LDK_NODE_POSTGRES_LOCK_FILE);
+	match write_new(&lock_path, &[], 0o600) {
+		Ok(()) => Ok(()),
+		Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => Ok(()),
+		Err(e) => {
+			Err(format!("Failed to persist PostgreSQL storage lock {}: {e}", lock_path.display()))
+		},
+	}
+}
+
+fn build_node(
+	builder: Builder, node_entropy: ldk_node::entropy::NodeEntropy,
+	ldk_node_storage: LdkNodeStorageConfig,
+) -> Result<Node, ldk_node::BuildError> {
+	match ldk_node_storage {
+		LdkNodeStorageConfig::Sqlite => builder.build(node_entropy),
+		LdkNodeStorageConfig::Postgres {
+			connection_string,
+			db_name,
+			kv_table_name,
+			certificate_pem,
+		} => builder.build_with_postgres_store(
+			node_entropy,
+			connection_string,
+			db_name,
+			kv_table_name,
+			certificate_pem,
+		),
+	}
+}
+
 fn send_event_and_upsert_payment(
 	payment_id: &PaymentId, payment_to_event: impl FnOnce(&Payment) -> event_envelope::Event,
 	event_node: &Node, event_sender: &broadcast::Sender<EventEnvelope>,
@@ -923,9 +1003,90 @@ fn build_payment_claimable_proto(
 
 #[cfg(test)]
 mod tests {
+	use std::fs;
+
 	use ldk_server_grpc::events::channel_state_change_reason::Details;
 
 	use super::*;
+
+	#[test]
+	fn postgres_storage_rejects_existing_sqlite_state() {
+		let network_dir = test_network_dir("postgres-rejects-sqlite");
+		let sqlite_path = network_dir.join(ldk_node::io::sqlite_store::SQLITE_DB_FILE_NAME);
+		fs::write(&sqlite_path, []).unwrap();
+		let postgres = LdkNodeStorageConfig::Postgres {
+			connection_string: "postgresql://localhost".to_string(),
+			db_name: None,
+			kv_table_name: None,
+			certificate_pem: None,
+		};
+
+		let err = ensure_no_unsupported_storage_migration(&network_dir, &postgres).unwrap_err();
+
+		assert!(err.contains("Refusing to switch LDK Node storage from SQLite to PostgreSQL"));
+		assert!(err.contains(sqlite_path.to_str().unwrap()));
+		fs::remove_dir_all(network_dir).unwrap();
+	}
+
+	#[test]
+	fn postgres_storage_allows_fresh_network_directory() {
+		let network_dir = test_network_dir("postgres-allows-fresh");
+		let postgres = LdkNodeStorageConfig::Postgres {
+			connection_string: "postgresql://localhost".to_string(),
+			db_name: None,
+			kv_table_name: None,
+			certificate_pem: None,
+		};
+
+		assert!(ensure_no_unsupported_storage_migration(&network_dir, &postgres).is_ok());
+		fs::remove_dir_all(network_dir).unwrap();
+	}
+
+	#[test]
+	fn sqlite_storage_allows_existing_sqlite_state() {
+		let network_dir = test_network_dir("sqlite-allows-sqlite");
+		let sqlite_path = network_dir.join(ldk_node::io::sqlite_store::SQLITE_DB_FILE_NAME);
+		fs::write(sqlite_path, []).unwrap();
+
+		assert!(ensure_no_unsupported_storage_migration(
+			&network_dir,
+			&LdkNodeStorageConfig::Sqlite
+		)
+		.is_ok());
+		fs::remove_dir_all(network_dir).unwrap();
+	}
+
+	#[test]
+	fn sqlite_storage_rejects_recorded_postgres_backend() {
+		let network_dir = test_network_dir("sqlite-rejects-postgres-marker");
+		fs::write(network_dir.join(LDK_NODE_POSTGRES_LOCK_FILE), []).unwrap();
+
+		let err =
+			ensure_no_unsupported_storage_migration(&network_dir, &LdkNodeStorageConfig::Sqlite)
+				.unwrap_err();
+
+		assert!(err.contains("Refusing to switch LDK Node storage from PostgreSQL to SQLite"));
+		fs::remove_dir_all(network_dir).unwrap();
+	}
+
+	#[test]
+	fn postgres_storage_lock_is_persisted_and_can_be_reopened() {
+		let network_dir = test_network_dir("postgres-lock-persists");
+
+		persist_postgres_storage_lock(&network_dir).unwrap();
+		persist_postgres_storage_lock(&network_dir).unwrap();
+
+		assert!(network_dir.join(LDK_NODE_POSTGRES_LOCK_FILE).exists());
+		fs::remove_dir_all(network_dir).unwrap();
+	}
+
+	fn test_network_dir(name: &str) -> PathBuf {
+		let dir = std::env::temp_dir()
+			.join(format!("ldk-server-storage-migration-test-{name}-{}", std::process::id()));
+		let _ = fs::remove_dir_all(&dir);
+		fs::create_dir(&dir).unwrap();
+		dir
+	}
 
 	#[test]
 	fn test_is_channel_open_failure_classification() {

--- a/ldk-server/src/util/config.rs
+++ b/ldk-server/src/util/config.rs
@@ -56,6 +56,7 @@ pub struct Config {
 	pub tls_config: Option<TlsConfig>,
 	pub grpc_service_addr: SocketAddr,
 	pub storage_dir_path: Option<String>,
+	pub ldk_node_storage: LdkNodeStorageConfig,
 	pub chain_source: ChainSource,
 	pub rgs_server_url: Option<String>,
 	pub lsps2_client_config: Option<LSPSClientConfig>,
@@ -92,6 +93,17 @@ pub struct TlsConfig {
 	pub hosts: Vec<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LdkNodeStorageConfig {
+	Sqlite,
+	Postgres {
+		connection_string: String,
+		db_name: Option<String>,
+		kv_table_name: Option<String>,
+		certificate_pem: Option<String>,
+	},
+}
+
 #[derive(Debug, PartialEq, Eq)]
 pub enum ChainSource {
 	Rpc {
@@ -126,6 +138,7 @@ struct ConfigBuilder {
 	tls_config: Option<TlsConfig>,
 	grpc_service_address: Option<String>,
 	storage_dir_path: Option<String>,
+	ldk_node_postgres: Option<PostgresStorageConfig>,
 	electrum_url: Option<String>,
 	esplora_url: Option<String>,
 	bitcoind_rpc_address: Option<String>,
@@ -171,8 +184,12 @@ impl ConfigBuilder {
 		}
 
 		if let Some(storage) = toml.storage {
-			self.storage_dir_path =
-				storage.disk.and_then(|d| d.dir_path).or(self.storage_dir_path.clone());
+			self.storage_dir_path = storage
+				.disk
+				.as_ref()
+				.and_then(|d| d.dir_path.clone())
+				.or(self.storage_dir_path.clone());
+			self.ldk_node_postgres = storage.postgres.or(self.ldk_node_postgres.clone());
 		}
 
 		if let Some(bitcoind) = toml.bitcoind {
@@ -278,6 +295,26 @@ impl ConfigBuilder {
 			self.storage_dir_path = Some(storage_dir_path.clone());
 		}
 
+		if args.storage_postgres_connection_string.is_some()
+			|| args.storage_postgres_db_name.is_some()
+			|| args.storage_postgres_kv_table_name.is_some()
+			|| args.storage_postgres_certificate_path.is_some()
+		{
+			let postgres = self.ldk_node_postgres.get_or_insert_default();
+			if let Some(connection_string) = &args.storage_postgres_connection_string {
+				postgres.connection_string = Some(connection_string.clone());
+			}
+			if let Some(db_name) = &args.storage_postgres_db_name {
+				postgres.db_name = Some(db_name.clone());
+			}
+			if let Some(kv_table_name) = &args.storage_postgres_kv_table_name {
+				postgres.kv_table_name = Some(kv_table_name.clone());
+			}
+			if let Some(certificate_path) = &args.storage_postgres_certificate_path {
+				postgres.certificate_path = Some(certificate_path.clone());
+			}
+		}
+
 		if let Some(pathfinding_scores_source_url) = &args.pathfinding_scores_source_url {
 			self.pathfinding_scores_source_url = Some(pathfinding_scores_source_url.clone());
 		}
@@ -287,7 +324,7 @@ impl ConfigBuilder {
 		}
 
 		if args.has_probing_options() {
-			let probing = self.probing.get_or_insert_with(ProbingTomlConfig::default);
+			let probing = self.probing.get_or_insert_default();
 			if let Some(probing_strategy) = &args.probing_strategy {
 				probing.strategy = Some(probing_strategy.clone());
 				match probing_strategy.trim().to_ascii_lowercase().as_str() {
@@ -499,6 +536,32 @@ impl ConfigBuilder {
 		let log_max_files = self.log_max_files.unwrap_or(DEFAULT_LOG_MAX_FILES);
 		let log_to_file = self.log_to_file.unwrap_or(true);
 
+		let ldk_node_storage = if let Some(postgres) = self.ldk_node_postgres {
+			LdkNodeStorageConfig::Postgres {
+				connection_string: postgres
+					.connection_string
+					.ok_or_else(|| missing_field_err("storage_postgres_connection_string"))?,
+				db_name: postgres.db_name,
+				kv_table_name: postgres.kv_table_name,
+				certificate_pem: postgres
+					.certificate_path
+					.map(|path| {
+						fs::read_to_string(&path).map_err(|e| {
+							io::Error::new(
+								e.kind(),
+								format!(
+									"Failed to read PostgreSQL certificate file '{}': {}",
+									path, e
+								),
+							)
+						})
+					})
+					.transpose()?,
+			}
+		} else {
+			LdkNodeStorageConfig::Sqlite
+		};
+
 		let lsps2_client_config = self
 			.lsps2
 			.as_ref()
@@ -582,6 +645,7 @@ impl ConfigBuilder {
 			tls_config: self.tls_config,
 			grpc_service_addr,
 			storage_dir_path: self.storage_dir_path,
+			ldk_node_storage,
 			chain_source,
 			rgs_server_url: self.rgs_server_url,
 			lsps2_client_config,
@@ -640,12 +704,22 @@ struct NodeConfig {
 #[serde(deny_unknown_fields)]
 struct StorageConfig {
 	disk: Option<DiskConfig>,
+	postgres: Option<PostgresStorageConfig>,
 }
 
 #[derive(Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 struct DiskConfig {
 	dir_path: Option<String>,
+}
+
+#[derive(Clone, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct PostgresStorageConfig {
+	connection_string: Option<String>,
+	db_name: Option<String>,
+	kv_table_name: Option<String>,
+	certificate_path: Option<String>,
 }
 
 #[derive(Deserialize, Serialize)]
@@ -1098,6 +1172,34 @@ pub struct ArgsConfig {
 
 	#[arg(
 		long,
+		env = "LDK_SERVER_STORAGE_POSTGRES_CONNECTION_STRING",
+		help = "PostgreSQL connection string for LDK Node wallet and channel state."
+	)]
+	storage_postgres_connection_string: Option<String>,
+
+	#[arg(
+		long,
+		env = "LDK_SERVER_STORAGE_POSTGRES_DB_NAME",
+		help = "Optional PostgreSQL database name for LDK Node storage."
+	)]
+	storage_postgres_db_name: Option<String>,
+
+	#[arg(
+		long,
+		env = "LDK_SERVER_STORAGE_POSTGRES_KV_TABLE_NAME",
+		help = "Optional PostgreSQL key-value table name for LDK Node storage."
+	)]
+	storage_postgres_kv_table_name: Option<String>,
+
+	#[arg(
+		long,
+		env = "LDK_SERVER_STORAGE_POSTGRES_CERTIFICATE_PATH",
+		help = "Optional path to a PEM-encoded CA certificate for TLS PostgreSQL connections."
+	)]
+	storage_postgres_certificate_path: Option<String>,
+
+	#[arg(
+		long,
 		env = "LDK_SERVER_PATHFINDING_SCORES_SOURCE_URL",
 		help = "The external scores source that is merged into the local scoring system to improve routing. Defaults to https://rapidsync.lightningdevkit.org/scoring/scorer.bin on mainnet. Set to an empty string to disable."
 	)]
@@ -1345,6 +1447,10 @@ mod tests {
 			rescan_from_height: None,
 			force_wallet_full_scan: false,
 			storage_dir_path: Some(String::from("/tmp_cli")),
+			storage_postgres_connection_string: None,
+			storage_postgres_db_name: None,
+			storage_postgres_kv_table_name: None,
+			storage_postgres_certificate_path: None,
 			node_alias: Some(String::from("LDK Server CLI")),
 			pathfinding_scores_source_url: Some(String::from("https://example.com/")),
 			node_async_payments_role: Some(String::from("server")),
@@ -1381,6 +1487,10 @@ mod tests {
 			rescan_from_height: None,
 			force_wallet_full_scan: false,
 			storage_dir_path: None,
+			storage_postgres_connection_string: None,
+			storage_postgres_db_name: None,
+			storage_postgres_kv_table_name: None,
+			storage_postgres_certificate_path: None,
 			pathfinding_scores_source_url: None,
 			node_async_payments_role: None,
 			probing_strategy: None,
@@ -1454,6 +1564,7 @@ mod tests {
 			network: Network::Regtest,
 			grpc_service_addr: SocketAddr::from_str("127.0.0.1:3002").unwrap(),
 			storage_dir_path: Some("/tmp".to_string()),
+			ldk_node_storage: LdkNodeStorageConfig::Sqlite,
 			tls_config: Some(TlsConfig {
 				cert_path: Some("/path/to/tls.crt".to_string()),
 				key_path: Some("/path/to/tls.key".to_string()),
@@ -1513,6 +1624,7 @@ mod tests {
 		assert_eq!(config.network, expected.network);
 		assert_eq!(config.grpc_service_addr, expected.grpc_service_addr);
 		assert_eq!(config.storage_dir_path, expected.storage_dir_path);
+		assert_eq!(config.ldk_node_storage, expected.ldk_node_storage);
 		assert_eq!(config.chain_source, expected.chain_source);
 		assert_eq!(config.rgs_server_url, expected.rgs_server_url);
 		assert_eq!(config.lsps2_client_config, expected.lsps2_client_config);
@@ -1524,7 +1636,6 @@ mod tests {
 		assert!(matches!(config.async_payments_role, Some(AsyncPaymentsRole::Client)));
 		assert_eq!(config.metrics_enabled, expected.metrics_enabled);
 		assert_eq!(config.tor_config, expected.tor_config);
-
 		// Test case where only electrum is set
 
 		let toml_config = r#"
@@ -1695,6 +1806,272 @@ mod tests {
 		fs::write(storage_path.join(config_file_name), toml_config).unwrap();
 		let error = load_config(&args_config).unwrap_err();
 		assert_eq!(error.to_string(), "Must set a single chain source, multiple were configured");
+	}
+
+	#[test]
+	fn test_postgres_storage_config_from_file() {
+		let storage_path = std::env::temp_dir();
+		let config_file_name = "test_postgres_storage_config_from_file.toml";
+		let cert_path = storage_path.join("test_postgres_storage_cert.pem");
+		fs::write(&cert_path, "-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----").unwrap();
+		let toml_config = format!(
+			r#"
+			[node]
+			network = "regtest"
+
+			[storage.disk]
+			dir_path = "/tmp"
+
+			[storage.postgres]
+			connection_string = "host=localhost user=postgres password=postgres"
+			db_name = "ldk_node"
+			kv_table_name = "ldk_node_kv"
+			certificate_path = "{}"
+
+			[bitcoind]
+			rpc_address = "127.0.0.1:8332"
+			rpc_user = "bitcoind-testuser"
+			rpc_password = "bitcoind-testpassword"
+			{}
+			"#,
+			cert_path.display(),
+			lsps2_service_config_for_feature()
+		);
+
+		fs::write(storage_path.join(config_file_name), toml_config).unwrap();
+
+		let mut args_config = empty_args_config();
+		args_config.config_file =
+			Some(storage_path.join(config_file_name).to_string_lossy().to_string());
+
+		let config = load_config(&args_config).unwrap();
+		assert_eq!(config.storage_dir_path, Some("/tmp".to_string()));
+		assert_eq!(
+			config.ldk_node_storage,
+			LdkNodeStorageConfig::Postgres {
+				connection_string: "host=localhost user=postgres password=postgres".to_string(),
+				db_name: Some("ldk_node".to_string()),
+				kv_table_name: Some("ldk_node_kv".to_string()),
+				certificate_pem: Some(
+					"-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----".to_string()
+				),
+			}
+		);
+	}
+
+	#[test]
+	fn test_postgres_storage_config_from_args() {
+		let storage_path = std::env::temp_dir();
+		let config_file_name = "test_postgres_storage_config_from_args.toml";
+		let cert_path = storage_path.join("test_postgres_storage_args_cert.pem");
+		fs::write(&cert_path, "-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----").unwrap();
+		let mut args_config = default_args_config();
+		args_config.config_file =
+			Some(storage_path.join(config_file_name).to_string_lossy().to_string());
+		fs::write(
+			storage_path.join(config_file_name),
+			format!(
+				r#"
+				[node]
+				network = "regtest"
+
+				[bitcoind]
+				rpc_address = "127.0.0.1:8332"
+				rpc_user = "bitcoind-testuser"
+				rpc_password = "bitcoind-testpassword"
+				{}
+				"#,
+				lsps2_service_config_for_feature()
+			),
+		)
+		.unwrap();
+		args_config.storage_postgres_connection_string =
+			Some("host=localhost user=postgres password=postgres".to_string());
+		args_config.storage_postgres_db_name = Some("ldk_node".to_string());
+		args_config.storage_postgres_kv_table_name = Some("ldk_node_kv".to_string());
+		args_config.storage_postgres_certificate_path =
+			Some(cert_path.to_string_lossy().to_string());
+
+		let config = load_config(&args_config).unwrap();
+		assert_eq!(
+			config.ldk_node_storage,
+			LdkNodeStorageConfig::Postgres {
+				connection_string: "host=localhost user=postgres password=postgres".to_string(),
+				db_name: Some("ldk_node".to_string()),
+				kv_table_name: Some("ldk_node_kv".to_string()),
+				certificate_pem: Some(
+					"-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----".to_string()
+				),
+			}
+		);
+	}
+
+	#[test]
+	fn test_postgres_storage_rejects_db_name_in_connection_string_and_field() {
+		let runtime = tokio::runtime::Runtime::new().unwrap();
+		let result = runtime.block_on(ldk_node::io::postgres_store::PostgresStore::new(
+			"postgresql://postgres@localhost/connection_string_db".to_string(),
+			Some("config_field_db".to_string()),
+			None,
+			None,
+		));
+		let error = match result {
+			Ok(_) => panic!("database names from both sources must be rejected"),
+			Err(error) => error,
+		};
+
+		assert_eq!(error.kind(), ldk_node::bitcoin::io::ErrorKind::InvalidInput);
+		assert!(
+			error.to_string().contains(
+				"db_name must not be set when the connection string already contains a dbname"
+			),
+			"unexpected error: {error}"
+		);
+	}
+
+	#[test]
+	fn test_postgres_storage_config_partial_combinations_from_file() {
+		let storage_path = std::env::temp_dir();
+		let cert_path = storage_path.join("test_postgres_storage_partial_cert.pem");
+		let cert_pem = "-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----";
+		fs::write(&cert_path, cert_pem).unwrap();
+
+		for mask in 0..8 {
+			let config_file_name =
+				format!("test_postgres_storage_config_partial_combinations_{mask}.toml");
+			let include_db_name = mask & 0b001 != 0;
+			let include_kv_table_name = mask & 0b010 != 0;
+			let include_certificate_path = mask & 0b100 != 0;
+
+			let db_name_line = if include_db_name { "db_name = \"ldk_node\"\n" } else { "" };
+			let kv_table_name_line =
+				if include_kv_table_name { "kv_table_name = \"ldk_node_kv\"\n" } else { "" };
+			let certificate_path_line = if include_certificate_path {
+				format!("certificate_path = \"{}\"\n", cert_path.display())
+			} else {
+				String::new()
+			};
+
+			let toml_config = format!(
+				r#"
+				[node]
+				network = "regtest"
+
+				[storage.postgres]
+				connection_string = "host=localhost user=postgres password=postgres"
+				{db_name_line}{kv_table_name_line}{certificate_path_line}
+
+				[bitcoind]
+				rpc_address = "127.0.0.1:8332"
+				rpc_user = "bitcoind-testuser"
+				rpc_password = "bitcoind-testpassword"
+				{}
+				"#,
+				lsps2_service_config_for_feature()
+			);
+
+			fs::write(storage_path.join(&config_file_name), toml_config).unwrap();
+
+			let mut args_config = empty_args_config();
+			args_config.config_file =
+				Some(storage_path.join(config_file_name).to_string_lossy().to_string());
+
+			let config = load_config(&args_config).unwrap();
+			assert_eq!(
+				config.ldk_node_storage,
+				LdkNodeStorageConfig::Postgres {
+					connection_string: "host=localhost user=postgres password=postgres".to_string(),
+					db_name: include_db_name.then(|| "ldk_node".to_string()),
+					kv_table_name: include_kv_table_name.then(|| "ldk_node_kv".to_string()),
+					certificate_pem: include_certificate_path.then(|| cert_pem.to_string()),
+				}
+			);
+		}
+	}
+
+	#[test]
+	fn test_postgres_storage_config_requires_connection_string_for_partial_file_configs() {
+		let storage_path = std::env::temp_dir();
+		let cert_path = storage_path.join("test_postgres_storage_missing_connection_cert.pem");
+		fs::write(&cert_path, "-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----").unwrap();
+
+		let cases = [
+			("", "empty_section"),
+			("db_name = \"ldk_node\"", "db_name"),
+			("kv_table_name = \"ldk_node_kv\"", "kv_table_name"),
+			(&format!("certificate_path = \"{}\"", cert_path.display()), "certificate_path"),
+			(
+				&format!(
+					"db_name = \"ldk_node\"\nkv_table_name = \"ldk_node_kv\"\ncertificate_path = \"{}\"",
+					cert_path.display()
+				),
+				"all_optional",
+			),
+		];
+
+		for (postgres_fields, case_name) in cases {
+			let config_file_name =
+				format!("test_postgres_storage_missing_connection_{case_name}.toml");
+			let toml_config = format!(
+				r#"
+				[node]
+				network = "regtest"
+
+				[storage.postgres]
+				{postgres_fields}
+
+				[bitcoind]
+				rpc_address = "127.0.0.1:8332"
+				rpc_user = "bitcoind-testuser"
+				rpc_password = "bitcoind-testpassword"
+				{}
+				"#,
+				lsps2_service_config_for_feature()
+			);
+
+			fs::write(storage_path.join(&config_file_name), toml_config).unwrap();
+
+			let mut args_config = empty_args_config();
+			args_config.config_file =
+				Some(storage_path.join(config_file_name).to_string_lossy().to_string());
+
+			let err = load_config(&args_config).unwrap_err();
+			assert_eq!(err.to_string(), missing_field_msg("storage_postgres_connection_string"));
+		}
+	}
+
+	#[test]
+	fn test_postgres_storage_config_requires_connection_string_for_partial_args_configs() {
+		let storage_path = std::env::temp_dir();
+		let cert_path = storage_path.join("test_postgres_storage_missing_args_connection_cert.pem");
+		fs::write(&cert_path, "-----BEGIN CERTIFICATE-----\n-----END CERTIFICATE-----").unwrap();
+
+		let mut cases = Vec::new();
+
+		let mut db_name_args = default_args_config();
+		db_name_args.storage_postgres_db_name = Some("ldk_node".to_string());
+		cases.push(db_name_args);
+
+		let mut kv_table_name_args = default_args_config();
+		kv_table_name_args.storage_postgres_kv_table_name = Some("ldk_node_kv".to_string());
+		cases.push(kv_table_name_args);
+
+		let mut certificate_path_args = default_args_config();
+		certificate_path_args.storage_postgres_certificate_path =
+			Some(cert_path.to_string_lossy().to_string());
+		cases.push(certificate_path_args);
+
+		let mut all_optional_args = default_args_config();
+		all_optional_args.storage_postgres_db_name = Some("ldk_node".to_string());
+		all_optional_args.storage_postgres_kv_table_name = Some("ldk_node_kv".to_string());
+		all_optional_args.storage_postgres_certificate_path =
+			Some(cert_path.to_string_lossy().to_string());
+		cases.push(all_optional_args);
+
+		for args_config in cases {
+			let err = load_config(&args_config).unwrap_err();
+			assert_eq!(err.to_string(), missing_field_msg("storage_postgres_connection_string"));
+		}
 	}
 
 	#[test]
@@ -1923,6 +2300,7 @@ mod tests {
 			.unwrap(),
 			alias: Some(parse_alias(args_config.node_alias.as_deref().unwrap()).unwrap()),
 			storage_dir_path: Some(args_config.storage_dir_path.unwrap()),
+			ldk_node_storage: LdkNodeStorageConfig::Sqlite,
 			tls_config: None,
 			chain_source: ChainSource::Rpc {
 				rpc_host: host,
@@ -1956,6 +2334,7 @@ mod tests {
 		assert_eq!(config.network, expected.network);
 		assert_eq!(config.grpc_service_addr, expected.grpc_service_addr);
 		assert_eq!(config.storage_dir_path, expected.storage_dir_path);
+		assert_eq!(config.ldk_node_storage, expected.ldk_node_storage);
 		assert_eq!(config.chain_source, expected.chain_source);
 		assert_eq!(config.rgs_server_url, expected.rgs_server_url);
 		assert!(config.lsps2_service_config.is_none());
@@ -2020,6 +2399,7 @@ mod tests {
 			.unwrap(),
 			alias: Some(parse_alias(args_config.node_alias.as_deref().unwrap()).unwrap()),
 			storage_dir_path: Some(args_config.storage_dir_path.unwrap()),
+			ldk_node_storage: LdkNodeStorageConfig::Sqlite,
 			tls_config: Some(TlsConfig {
 				cert_path: Some("/path/to/tls.crt".to_string()),
 				key_path: Some("/path/to/tls.key".to_string()),
@@ -2078,6 +2458,7 @@ mod tests {
 		assert_eq!(config.network, expected.network);
 		assert_eq!(config.grpc_service_addr, expected.grpc_service_addr);
 		assert_eq!(config.storage_dir_path, expected.storage_dir_path);
+		assert_eq!(config.ldk_node_storage, expected.ldk_node_storage);
 		assert_eq!(config.chain_source, expected.chain_source);
 		assert_eq!(config.rgs_server_url, expected.rgs_server_url);
 		assert_eq!(config.lsps2_client_config, expected.lsps2_client_config);


### PR DESCRIPTION
Allow ldk-server to configure LDK Node wallet state, channel state, and payment history through PostgreSQL without a feature-gated server build. Keep local disk storage for server-owned files and forwarded-payment history, and document the backup and per-network isolation boundaries.

Refuse switching between SQLite and PostgreSQL after initialization. The local marker records only the backend type; it does not detect a changed PostgreSQL database or table, or missing state.

Limit PostgreSQL certificate reads to 1 MiB and test oversized and unbounded inputs. Remove the Getting Started claim that no other external dependencies are required.

Validation: formatting, default and all-feature tests, and Clippy passed.

AI-assisted-by: OpenAI Codex
