### PR TITLE
Expose background probing service 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,7 +302,7 @@ checksum = "0b47c4ab7a93edb0c7198c5535ed9b52b63095f4e9b45279c6736cec4b856baf"
 [[package]]
 name = "bitcoin-payment-instructions"
 version = "0.6.0"
-source = "git+https://github.com/tnull/bitcoin-payment-instructions?rev=ff09ce9401afa448549a8f101172700bcd14d7bb#ff09ce9401afa448549a8f101172700bcd14d7bb"
+source = "git+https://github.com/tnull/bitcoin-payment-instructions?rev=0e430be98c09540624a68a68022ee0551e86d1be#0e430be98c09540624a68a68022ee0551e86d1be"
 dependencies = [
  "bitcoin",
  "dnssec-prover",
@@ -346,17 +346,17 @@ checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "bitreq"
-version = "0.3.4"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08221cf31c5f00fb6fc8fa697cea54176b06801a518bd9d3482aa27099827a3a"
+checksum = "b65c2e1ab98050c93cc9ada070d5070e014329c65196d03f6f8f1f75c2666f37"
 dependencies = [
- "rustls 0.21.12",
- "rustls-webpki 0.101.7",
+ "rustls 0.23.42",
+ "rustls-webpki 0.103.13",
  "serde",
  "serde_json",
  "tokio",
- "tokio-rustls 0.24.1",
- "webpki-roots 0.25.4",
+ "tokio-rustls 0.26.4",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -544,7 +544,7 @@ dependencies = [
  "byteorder",
  "libc",
  "log",
- "rustls 0.23.34",
+ "rustls 0.23.42",
  "serde",
  "serde_json",
  "webpki-roots 0.25.4",
@@ -573,7 +573,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1016,12 +1016,12 @@ dependencies = [
  "http 1.3.1",
  "hyper 1.7.0",
  "hyper-util",
- "rustls 0.23.34",
+ "rustls 0.23.42",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
- "webpki-roots 1.0.3",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -1054,7 +1054,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -1266,7 +1266,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "ldk-node"
 version = "0.8.0+git"
-source = "git+https://github.com/lightningdevkit/ldk-node?rev=f2e44fdd21490ff3fa90445d7a28b19cfd020c3d#f2e44fdd21490ff3fa90445d7a28b19cfd020c3d"
+source = "git+https://github.com/lightningdevkit/ldk-node?rev=056447c28221be02c3d39f8c6ae430a67ebbd850#056447c28221be02c3d39f8c6ae430a67ebbd850"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1299,7 +1299,7 @@ dependencies = [
  "log",
  "prost",
  "rusqlite",
- "rustls 0.23.34",
+ "rustls 0.23.42",
  "serde",
  "serde_json",
  "tokio",
@@ -1420,7 +1420,7 @@ dependencies = [
 [[package]]
 name = "lightning"
 version = "0.3.0+git"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=3dfcc4cca1866c5e5d4d4eaf3b82e09584e2ce5c#3dfcc4cca1866c5e5d4d4eaf3b82e09584e2ce5c"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=506cb91f2e0fb87906188b79777bcf42595d3623#506cb91f2e0fb87906188b79777bcf42595d3623"
 dependencies = [
  "bech32",
  "bitcoin",
@@ -1437,7 +1437,7 @@ dependencies = [
 [[package]]
 name = "lightning-background-processor"
 version = "0.3.0+git"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=3dfcc4cca1866c5e5d4d4eaf3b82e09584e2ce5c#3dfcc4cca1866c5e5d4d4eaf3b82e09584e2ce5c"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=506cb91f2e0fb87906188b79777bcf42595d3623#506cb91f2e0fb87906188b79777bcf42595d3623"
 dependencies = [
  "bitcoin",
  "bitcoin-io",
@@ -1451,7 +1451,7 @@ dependencies = [
 [[package]]
 name = "lightning-block-sync"
 version = "0.3.0+git"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=3dfcc4cca1866c5e5d4d4eaf3b82e09584e2ce5c#3dfcc4cca1866c5e5d4d4eaf3b82e09584e2ce5c"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=506cb91f2e0fb87906188b79777bcf42595d3623#506cb91f2e0fb87906188b79777bcf42595d3623"
 dependencies = [
  "bitcoin",
  "bitreq",
@@ -1463,7 +1463,7 @@ dependencies = [
 [[package]]
 name = "lightning-dns-resolver"
 version = "0.3.0+git"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=3dfcc4cca1866c5e5d4d4eaf3b82e09584e2ce5c#3dfcc4cca1866c5e5d4d4eaf3b82e09584e2ce5c"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=506cb91f2e0fb87906188b79777bcf42595d3623#506cb91f2e0fb87906188b79777bcf42595d3623"
 dependencies = [
  "dnssec-prover",
  "lightning",
@@ -1474,7 +1474,7 @@ dependencies = [
 [[package]]
 name = "lightning-invoice"
 version = "0.35.0+git"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=3dfcc4cca1866c5e5d4d4eaf3b82e09584e2ce5c#3dfcc4cca1866c5e5d4d4eaf3b82e09584e2ce5c"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=506cb91f2e0fb87906188b79777bcf42595d3623#506cb91f2e0fb87906188b79777bcf42595d3623"
 dependencies = [
  "bech32",
  "bitcoin",
@@ -1485,7 +1485,7 @@ dependencies = [
 [[package]]
 name = "lightning-liquidity"
 version = "0.3.0+git"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=3dfcc4cca1866c5e5d4d4eaf3b82e09584e2ce5c#3dfcc4cca1866c5e5d4d4eaf3b82e09584e2ce5c"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=506cb91f2e0fb87906188b79777bcf42595d3623#506cb91f2e0fb87906188b79777bcf42595d3623"
 dependencies = [
  "bitcoin",
  "bitreq",
@@ -1501,7 +1501,7 @@ dependencies = [
 [[package]]
 name = "lightning-macros"
 version = "0.2.2+git"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=3dfcc4cca1866c5e5d4d4eaf3b82e09584e2ce5c#3dfcc4cca1866c5e5d4d4eaf3b82e09584e2ce5c"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=506cb91f2e0fb87906188b79777bcf42595d3623#506cb91f2e0fb87906188b79777bcf42595d3623"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1511,7 +1511,7 @@ dependencies = [
 [[package]]
 name = "lightning-net-tokio"
 version = "0.3.0+git"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=3dfcc4cca1866c5e5d4d4eaf3b82e09584e2ce5c#3dfcc4cca1866c5e5d4d4eaf3b82e09584e2ce5c"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=506cb91f2e0fb87906188b79777bcf42595d3623#506cb91f2e0fb87906188b79777bcf42595d3623"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1521,7 +1521,7 @@ dependencies = [
 [[package]]
 name = "lightning-persister"
 version = "0.3.0+git"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=3dfcc4cca1866c5e5d4d4eaf3b82e09584e2ce5c#3dfcc4cca1866c5e5d4d4eaf3b82e09584e2ce5c"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=506cb91f2e0fb87906188b79777bcf42595d3623#506cb91f2e0fb87906188b79777bcf42595d3623"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1532,7 +1532,7 @@ dependencies = [
 [[package]]
 name = "lightning-rapid-gossip-sync"
 version = "0.3.0+git"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=3dfcc4cca1866c5e5d4d4eaf3b82e09584e2ce5c#3dfcc4cca1866c5e5d4d4eaf3b82e09584e2ce5c"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=506cb91f2e0fb87906188b79777bcf42595d3623#506cb91f2e0fb87906188b79777bcf42595d3623"
 dependencies = [
  "bitcoin",
  "bitcoin-io",
@@ -1543,7 +1543,7 @@ dependencies = [
 [[package]]
 name = "lightning-transaction-sync"
 version = "0.3.0+git"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=3dfcc4cca1866c5e5d4d4eaf3b82e09584e2ce5c#3dfcc4cca1866c5e5d4d4eaf3b82e09584e2ce5c"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=506cb91f2e0fb87906188b79777bcf42595d3623#506cb91f2e0fb87906188b79777bcf42595d3623"
 dependencies = [
  "bitcoin",
  "electrum-client",
@@ -1556,7 +1556,7 @@ dependencies = [
 [[package]]
 name = "lightning-types"
 version = "0.4.0+git"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=3dfcc4cca1866c5e5d4d4eaf3b82e09584e2ce5c#3dfcc4cca1866c5e5d4d4eaf3b82e09584e2ce5c"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=506cb91f2e0fb87906188b79777bcf42595d3623#506cb91f2e0fb87906188b79777bcf42595d3623"
 dependencies = [
  "bitcoin",
 ]
@@ -1715,7 +1715,7 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 [[package]]
 name = "possiblyrandom"
 version = "0.2.0"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=3dfcc4cca1866c5e5d4d4eaf3b82e09584e2ce5c#3dfcc4cca1866c5e5d4d4eaf3b82e09584e2ce5c"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=506cb91f2e0fb87906188b79777bcf42595d3623#506cb91f2e0fb87906188b79777bcf42595d3623"
 dependencies = [
  "getrandom 0.2.16",
 ]
@@ -1823,8 +1823,8 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.34",
- "socket2 0.6.1",
+ "rustls 0.23.42",
+ "socket2 0.5.10",
  "thiserror",
  "tokio",
  "tracing",
@@ -1843,7 +1843,7 @@ dependencies = [
  "rand 0.9.2",
  "ring",
  "rustc-hash",
- "rustls 0.23.34",
+ "rustls 0.23.42",
  "rustls-pki-types",
  "slab",
  "thiserror",
@@ -1861,9 +1861,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.1",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2030,7 +2030,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.34",
+ "rustls 0.23.42",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -2045,7 +2045,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 1.0.3",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -2105,7 +2105,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2122,16 +2122,16 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.34"
+version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a9586e9ee2b4f8fab52a0048ca7334d7024eef48e2cb9407e3497bb7cab7fa7"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.8",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -2167,9 +2167,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.8"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -2428,7 +2428,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2529,7 +2529,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.34",
+ "rustls 0.23.42",
  "tokio",
 ]
 
@@ -2903,9 +2903,9 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.3"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b130c0d2d49f8b6889abc456e795e82525204f27c42cf767cf0d7734e089b8"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/contrib/ldk-server-config.toml
+++ b/contrib/ldk-server-config.toml
@@ -9,6 +9,23 @@ alias = "ldk_server"                          # Lightning node alias
 #rgs_server_url = "https://rapidsync.lightningdevkit.org/snapshot/v2/"  # Optional: RGS URL for rapid gossip sync
 #async_payments_role = "client"               # Optional async payments role: "client" or "server"
 
+# Background probing service (optional)
+# CAUTION: Probes send real HTLCs and can lock outbound liquidity until they time out.
+# See docs/configuration.md for complete field descriptions.
+# Set only the field required by the selected strategy.
+# "high_degree" requires top_node_count. "random_walk" requires max_hops.
+#[probing]
+#strategy = "high_degree"                     # Required. No default. See the strategy recommendations in the documentation.
+#top_node_count = 100                          # Required for "high_degree". No default. Start with 100.
+# max_hops must be at least 2. LDK Node changes values greater than 19 to 19.
+#max_hops = 5                                  # Required for "random_walk". No default. Start with 5.
+#interval_secs = 10                            # Time between probe attempts (default: 10 seconds)
+# Built-in probes use at least 1000000 msat before routing fees. Lower limits prevent all probes.
+#max_locked_msat = 100000000                   # Maximum total in-flight probe liquidity (default: 100k sats)
+# This virtual scorer cost is not paid. It decreases to zero over 24 hours.
+#diversity_penalty_msat = 250                  # Optional. Only affects "high_degree".
+#cooldown_secs = 3600                          # Node re-probe cooldown for "high_degree" (default: 1 hour)
+
 # Storage settings
 [storage.disk]
 dir_path = "/tmp/ldk-server/"                 # Path for LDK and BDK data persistence, optional, defaults to ~/Library/Application Support/ldk-server/ on macOS, ~/.ldk-server/ on Linux

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -59,6 +59,45 @@ this node to go offline. Set `async_payments_role = "server"` to hold async paym
 and onion messages for peers. The server role requires an announceable node configuration.
 Leave the field unset to disable async payments.
 
+### `[probing]`
+
+Enables LDK Node's background probing service to train the payment scorer with current
+channel-liquidity information. Probing is disabled when this section and the corresponding
+CLI/environment options are absent.
+
+The `strategy` field selects one of two path-selection methods:
+
+- **`"high_degree"`** probes toward highly connected public nodes. The service uses the
+  payment scorer to select a path.
+- **`"random_walk"`** constructs random paths through the public graph. This strategy does
+  not use the payment scorer to select a path.
+
+The section accepts these fields:
+
+| Field | Requirement and default | Description |
+| --- | --- | --- |
+| `strategy` | Required. No default. | Selects `"high_degree"` or `"random_walk"`. Start with `"random_walk"` for a payment node. Use `"high_degree"` for a dedicated probing node. |
+| `top_node_count` | Required for `"high_degree"`. No default. Start with `100`. | Sets the number of highly connected public nodes in the destination set. The strategy cycles through this set. The value must be greater than `0`. |
+| `max_hops` | Required for `"random_walk"`. No default. Start with `5`. | Sets the maximum number of hops in a random path. The value must be at least `2`. LDK Node changes values greater than `19` to `19`. |
+| `interval_secs` | Optional. The default is `10`. | Sets the number of seconds between probe attempts. LDK Node changes `0` to its minimum interval of 100 milliseconds. |
+| `max_locked_msat` | Optional. The default is `100000000` (100,000 satoshis). | Limits the total amount and pending fees of in-flight probes. The service skips a probe that exceeds the remaining limit. Built-in probes use 1,000,000 through 10,000,000 millisatoshis before routing fees. |
+| `diversity_penalty_msat` | Optional. The default is `0`. | Adds a virtual routing cost to recently probed channels. The service does not pay this amount. The cost decreases to zero over 24 hours and encourages different paths. This field only affects `"high_degree"`. |
+| `cooldown_secs` | Optional. The default is `3600`. | Sets the time before `"high_degree"` can select the same destination again. The strategy starts a new cycle immediately after it probes all destinations. |
+
+```toml
+[probing]
+strategy = "high_degree"
+top_node_count = 100
+interval_secs = 30
+max_locked_msat = 100000000
+diversity_penalty_msat = 250
+cooldown_secs = 3600
+```
+
+> [!CAUTION]
+> Probes send real HTLCs over real channels. A probe can lock outbound liquidity
+> until its HTLC expires. Use `max_locked_msat` to limit this risk.
+
 ### `[storage.disk]`
 
 Where persistent data is stored. Defaults to `~/.ldk-server/` on Linux and

--- a/e2e-tests/Cargo.lock
+++ b/e2e-tests/Cargo.lock
@@ -74,6 +74,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "pkg-config",
+]
+
+[[package]]
 name = "base58ck"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -126,9 +149,9 @@ dependencies = [
 
 [[package]]
 name = "bdk_electrum"
-version = "0.23.2"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b59a3f7fbe678874fa34354097644a171276e02a49934c13b3d61c54610ddf39"
+checksum = "00a9846105bf6e751adbb6946b000ff919ce24a15a941cbfe68485549b552a9c"
 dependencies = [
  "bdk_core",
  "electrum-client",
@@ -148,9 +171,9 @@ dependencies = [
 
 [[package]]
 name = "bdk_wallet"
-version = "2.3.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b03f1e31ccc562f600981f747d2262b84428cbff52c9c9cdf14d15fb15bd2286"
+checksum = "1284fb23acc3e3022673712b55f4d5ce7e38aadc2c49bbef830dc3935f0a3289"
 dependencies = [
  "bdk_chain",
  "bip39",
@@ -227,7 +250,7 @@ checksum = "2dee39a0ee5b4095224a0cfc6bf4cc1baf0f9624b96b367e53b66d974e51d953"
 [[package]]
 name = "bitcoin-payment-instructions"
 version = "0.6.0"
-source = "git+https://github.com/jkczyz/bitcoin-payment-instructions?rev=a7b32d5fded9bb45f73bf82e6d7187adf705171c#a7b32d5fded9bb45f73bf82e6d7187adf705171c"
+source = "git+https://github.com/tnull/bitcoin-payment-instructions?rev=0e430be98c09540624a68a68022ee0551e86d1be#0e430be98c09540624a68a68022ee0551e86d1be"
 dependencies = [
  "bitcoin",
  "dnssec-prover",
@@ -271,17 +294,17 @@ checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "bitreq"
-version = "0.3.4"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08221cf31c5f00fb6fc8fa697cea54176b06801a518bd9d3482aa27099827a3a"
+checksum = "b65c2e1ab98050c93cc9ada070d5070e014329c65196d03f6f8f1f75c2666f37"
 dependencies = [
- "rustls 0.21.12",
- "rustls-webpki 0.101.7",
+ "rustls 0.23.42",
+ "rustls-webpki 0.103.13",
  "serde",
  "serde_json",
  "tokio",
- "tokio-rustls 0.24.1",
- "webpki-roots 0.25.4",
+ "tokio-rustls 0.26.4",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -332,6 +355,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -354,6 +379,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b4b0fc281743d80256607bd65e8beedc42cb0787ea119c85b81b4c0eab85e5f"
 
 [[package]]
+name = "chacha20-poly1305"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad28386ab70dd960294556a76aaab6da2994fec47d650fd725b3012f062052a"
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -363,6 +394,15 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-link",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -462,6 +502,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "e2e-tests"
 version = "0.1.0"
 dependencies = [
@@ -483,15 +529,15 @@ checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "electrum-client"
-version = "0.24.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5059f13888a90486e7268bbce59b175f5f76b1c55e5b9c568ceaa42d2b8507c"
+checksum = "1970c5d7bd9de6d4041cbfc3e46faa3e85fe7efcea2b0eb06750d3ae1ef577b7"
 dependencies = [
  "bitcoin",
  "byteorder",
  "libc",
  "log",
- "rustls 0.23.37",
+ "rustls 0.23.42",
  "serde",
  "serde_json",
  "webpki-roots 0.25.4",
@@ -520,7 +566,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -609,6 +655,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -967,12 +1019,12 @@ dependencies = [
  "http 1.4.0",
  "hyper 1.9.0",
  "hyper-util",
- "rustls 0.23.37",
+ "rustls 0.23.42",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.4",
  "tower-service",
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -992,7 +1044,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -1175,6 +1227,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.2",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1207,7 +1269,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 [[package]]
 name = "ldk-node"
 version = "0.8.0+git"
-source = "git+https://github.com/lightningdevkit/ldk-node?rev=c754e2fe85c70741b5e370334cd16856c615265e#c754e2fe85c70741b5e370334cd16856c615265e"
+source = "git+https://github.com/lightningdevkit/ldk-node?rev=056447c28221be02c3d39f8c6ae430a67ebbd850#056447c28221be02c3d39f8c6ae430a67ebbd850"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1228,6 +1290,7 @@ dependencies = [
  "lightning",
  "lightning-background-processor",
  "lightning-block-sync",
+ "lightning-dns-resolver",
  "lightning-invoice",
  "lightning-liquidity",
  "lightning-macros",
@@ -1239,7 +1302,7 @@ dependencies = [
  "log",
  "prost",
  "rusqlite",
- "rustls 0.23.37",
+ "rustls 0.23.42",
  "serde",
  "serde_json",
  "tokio",
@@ -1319,10 +1382,11 @@ dependencies = [
 [[package]]
 name = "lightning"
 version = "0.3.0+git"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=38a62c32454d3eac22578144c479dbf9a6d9bff6#38a62c32454d3eac22578144c479dbf9a6d9bff6"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=506cb91f2e0fb87906188b79777bcf42595d3623#506cb91f2e0fb87906188b79777bcf42595d3623"
 dependencies = [
  "bech32",
  "bitcoin",
+ "chacha20-poly1305 0.2.0",
  "dnssec-prover",
  "hashbrown 0.13.2",
  "libm",
@@ -1335,7 +1399,7 @@ dependencies = [
 [[package]]
 name = "lightning-background-processor"
 version = "0.3.0+git"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=38a62c32454d3eac22578144c479dbf9a6d9bff6#38a62c32454d3eac22578144c479dbf9a6d9bff6"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=506cb91f2e0fb87906188b79777bcf42595d3623#506cb91f2e0fb87906188b79777bcf42595d3623"
 dependencies = [
  "bitcoin",
  "bitcoin-io",
@@ -1349,7 +1413,7 @@ dependencies = [
 [[package]]
 name = "lightning-block-sync"
 version = "0.3.0+git"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=38a62c32454d3eac22578144c479dbf9a6d9bff6#38a62c32454d3eac22578144c479dbf9a6d9bff6"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=506cb91f2e0fb87906188b79777bcf42595d3623#506cb91f2e0fb87906188b79777bcf42595d3623"
 dependencies = [
  "bitcoin",
  "bitreq",
@@ -1359,9 +1423,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "lightning-dns-resolver"
+version = "0.3.0+git"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=506cb91f2e0fb87906188b79777bcf42595d3623#506cb91f2e0fb87906188b79777bcf42595d3623"
+dependencies = [
+ "dnssec-prover",
+ "lightning",
+ "lightning-types",
+ "tokio",
+]
+
+[[package]]
 name = "lightning-invoice"
 version = "0.35.0+git"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=38a62c32454d3eac22578144c479dbf9a6d9bff6#38a62c32454d3eac22578144c479dbf9a6d9bff6"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=506cb91f2e0fb87906188b79777bcf42595d3623#506cb91f2e0fb87906188b79777bcf42595d3623"
 dependencies = [
  "bech32",
  "bitcoin",
@@ -1372,9 +1447,10 @@ dependencies = [
 [[package]]
 name = "lightning-liquidity"
 version = "0.3.0+git"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=38a62c32454d3eac22578144c479dbf9a6d9bff6#38a62c32454d3eac22578144c479dbf9a6d9bff6"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=506cb91f2e0fb87906188b79777bcf42595d3623#506cb91f2e0fb87906188b79777bcf42595d3623"
 dependencies = [
  "bitcoin",
+ "bitreq",
  "chrono",
  "lightning",
  "lightning-invoice",
@@ -1387,7 +1463,7 @@ dependencies = [
 [[package]]
 name = "lightning-macros"
 version = "0.2.2+git"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=38a62c32454d3eac22578144c479dbf9a6d9bff6#38a62c32454d3eac22578144c479dbf9a6d9bff6"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=506cb91f2e0fb87906188b79777bcf42595d3623#506cb91f2e0fb87906188b79777bcf42595d3623"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1397,7 +1473,7 @@ dependencies = [
 [[package]]
 name = "lightning-net-tokio"
 version = "0.3.0+git"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=38a62c32454d3eac22578144c479dbf9a6d9bff6#38a62c32454d3eac22578144c479dbf9a6d9bff6"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=506cb91f2e0fb87906188b79777bcf42595d3623#506cb91f2e0fb87906188b79777bcf42595d3623"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1407,7 +1483,7 @@ dependencies = [
 [[package]]
 name = "lightning-persister"
 version = "0.3.0+git"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=38a62c32454d3eac22578144c479dbf9a6d9bff6#38a62c32454d3eac22578144c479dbf9a6d9bff6"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=506cb91f2e0fb87906188b79777bcf42595d3623#506cb91f2e0fb87906188b79777bcf42595d3623"
 dependencies = [
  "bitcoin",
  "lightning",
@@ -1418,7 +1494,7 @@ dependencies = [
 [[package]]
 name = "lightning-rapid-gossip-sync"
 version = "0.3.0+git"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=38a62c32454d3eac22578144c479dbf9a6d9bff6#38a62c32454d3eac22578144c479dbf9a6d9bff6"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=506cb91f2e0fb87906188b79777bcf42595d3623#506cb91f2e0fb87906188b79777bcf42595d3623"
 dependencies = [
  "bitcoin",
  "bitcoin-io",
@@ -1429,7 +1505,7 @@ dependencies = [
 [[package]]
 name = "lightning-transaction-sync"
 version = "0.3.0+git"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=38a62c32454d3eac22578144c479dbf9a6d9bff6#38a62c32454d3eac22578144c479dbf9a6d9bff6"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=506cb91f2e0fb87906188b79777bcf42595d3623#506cb91f2e0fb87906188b79777bcf42595d3623"
 dependencies = [
  "bitcoin",
  "electrum-client",
@@ -1442,7 +1518,7 @@ dependencies = [
 [[package]]
 name = "lightning-types"
 version = "0.4.0+git"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=38a62c32454d3eac22578144c479dbf9a6d9bff6#38a62c32454d3eac22578144c479dbf9a6d9bff6"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=506cb91f2e0fb87906188b79777bcf42595d3623#506cb91f2e0fb87906188b79777bcf42595d3623"
 dependencies = [
  "bitcoin",
 ]
@@ -1598,7 +1674,7 @@ checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 [[package]]
 name = "possiblyrandom"
 version = "0.2.0"
-source = "git+https://github.com/lightningdevkit/rust-lightning?rev=38a62c32454d3eac22578144c479dbf9a6d9bff6#38a62c32454d3eac22578144c479dbf9a6d9bff6"
+source = "git+https://github.com/lightningdevkit/rust-lightning?rev=506cb91f2e0fb87906188b79777bcf42595d3623#506cb91f2e0fb87906188b79777bcf42595d3623"
 dependencies = [
  "getrandom 0.2.17",
 ]
@@ -1716,8 +1792,8 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.37",
- "socket2 0.6.3",
+ "rustls 0.23.42",
+ "socket2 0.5.10",
  "thiserror",
  "tokio",
  "tracing",
@@ -1736,7 +1812,7 @@ dependencies = [
  "rand 0.9.2",
  "ring",
  "rustc-hash",
- "rustls 0.23.37",
+ "rustls 0.23.42",
  "rustls-pki-types",
  "slab",
  "thiserror",
@@ -1754,7 +1830,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -1938,7 +2014,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.37",
+ "rustls 0.23.42",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -1953,7 +2029,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots 1.0.6",
+ "webpki-roots 1.0.9",
 ]
 
 [[package]]
@@ -2013,7 +2089,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2030,15 +2106,16 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -2074,10 +2151,11 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -2228,7 +2306,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2330,10 +2408,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2423,7 +2501,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.37",
+ "rustls 0.23.42",
  "tokio",
 ]
 
@@ -2569,16 +2647,16 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "vss-client-ng"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6334cb4940aba86a2e2aa9dde7c722a2510f55815422088a2a2ac24f46579e6a"
+checksum = "49dae7224f498977c17c2ac85d5377d6a2b7290102add15070db257b86a519d6"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bitcoin",
  "bitcoin_hashes",
  "bitreq",
- "chacha20-poly1305",
+ "chacha20-poly1305 0.1.2",
  "log",
  "prost",
  "prost-build",
@@ -2738,9 +2816,9 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/e2e-tests/Cargo.toml
+++ b/e2e-tests/Cargo.toml
@@ -21,4 +21,4 @@ ldk-server-client = { path = "../ldk-server-client" }
 ldk-server-grpc = { path = "../ldk-server-grpc", features = ["serde"] }
 serde_json = "1.0"
 hex-conservative = { version = "0.2", features = ["std"] }
-ldk-node = { git = "https://github.com/lightningdevkit/ldk-node", rev = "c754e2fe85c70741b5e370334cd16856c615265e" }
+ldk-node = { git = "https://github.com/lightningdevkit/ldk-node", rev = "056447c28221be02c3d39f8c6ae430a67ebbd850" }

--- a/e2e-tests/tests/e2e.rs
+++ b/e2e-tests/tests/e2e.rs
@@ -1200,12 +1200,12 @@ async fn test_forwarded_payment_event() {
 
 	let mut builder_c = ldk_node::Builder::from_config(config_c);
 	let (rpc_host, rpc_port, rpc_user, rpc_password) = bitcoind.rpc_details();
-	builder_c.set_chain_source_bitcoind_rpc(rpc_host, rpc_port, rpc_user, rpc_password);
+	builder_c.set_chain_source_bitcoind_rpc(rpc_host, rpc_port, rpc_user, rpc_password, None);
 
 	// Set B as LSPS2 LSP for C
 	let b_node_id = ldk_node::bitcoin::secp256k1::PublicKey::from_str(server_b.node_id()).unwrap();
 	let b_addr = SocketAddress::from_str(&format!("127.0.0.1:{}", server_b.p2p_port)).unwrap();
-	builder_c.set_liquidity_source_lsps2(b_node_id, b_addr, None);
+	builder_c.add_liquidity_source(b_node_id, b_addr, None, true);
 
 	let mnemonic_c = ldk_node::entropy::generate_entropy_mnemonic(None);
 	let node_entropy_c = ldk_node::entropy::NodeEntropy::from_bip39_mnemonic(mnemonic_c, None);

--- a/ldk-server/Cargo.toml
+++ b/ldk-server/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["bitcoin", "lightning", "ldk", "server"]
 categories = ["cryptography::cryptocurrencies"]
 
 [dependencies]
-ldk-node = { git = "https://github.com/lightningdevkit/ldk-node", rev = "f2e44fdd21490ff3fa90445d7a28b19cfd020c3d" }
+ldk-node = { git = "https://github.com/lightningdevkit/ldk-node", rev = "056447c28221be02c3d39f8c6ae430a67ebbd850" }
 serde = { version = "1.0.203", default-features = false, features = ["derive"] }
 hyper = { version = "1", default-features = false, features = ["server", "http2"] }
 http-body-util = { version = "0.1", default-features = false }

--- a/ldk-server/src/api/error.rs
+++ b/ldk-server/src/api/error.rs
@@ -129,6 +129,7 @@ impl From<NodeError> for LdkServerError {
 			| NodeError::LnurlAuthFailed
 			| NodeError::LnurlAuthTimeout
 			| NodeError::InvalidLnurl
+			| NodeError::ChainSourceNotSupported
 			| NodeError::TxSyncTimeout => (error.to_string(), LdkServerErrorCode::InternalServerError),
 		};
 		LdkServerError::new(error_code, message)

--- a/ldk-server/src/main.rs
+++ b/ldk-server/src/main.rs
@@ -207,6 +207,10 @@ fn main() {
 		builder.set_gossip_source_rgs(rgs_server_url);
 	}
 
+	if let Some(probing_config) = config_file.probing_config {
+		builder.set_probing_config(probing_config);
+	}
+
 	if let Err(e) = builder.set_async_payments_role(config_file.async_payments_role) {
 		error!("Failed to configure async payments role: {e}");
 		std::process::exit(-1);

--- a/ldk-server/src/main.rs
+++ b/ldk-server/src/main.rs
@@ -443,8 +443,8 @@ fn main() {
 								reason,
 							} => {
 								info!(
-									"CHANNEL_CLOSED: {} from counterparty {:?}",
-									channel_id, counterparty_node_id.map(|p| p.to_string()),
+									"CHANNEL_CLOSED: {} from counterparty {}",
+									channel_id, counterparty_node_id,
 								);
 
 								let channel_id_hex = channel_id.0.to_lower_hex_string();
@@ -456,8 +456,7 @@ fn main() {
 									event_envelope::Event::ChannelStateChanged(events::ChannelStateChanged {
 										channel_id: channel_id_hex,
 										user_channel_id: user_channel_id.0.to_string(),
-										counterparty_node_id: counterparty_node_id
-											.map(|node_id| node_id.to_string()),
+										counterparty_node_id: Some(counterparty_node_id.to_string()),
 										state: if is_open_failure {
 											events::ChannelState::OpenFailed.into()
 										} else {

--- a/ldk-server/src/util/config.rs
+++ b/ldk-server/src/util/config.rs
@@ -10,6 +10,7 @@
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::str::FromStr;
+use std::time::Duration;
 use std::{fs, io};
 
 use clap::Parser;
@@ -19,6 +20,7 @@ use ldk_node::config::{AsyncPaymentsRole, HRNResolverConfig, HumanReadableNamesC
 use ldk_node::lightning::ln::msgs::SocketAddress;
 use ldk_node::lightning::routing::gossip::NodeAlias;
 use ldk_node::liquidity::LSPS2ServiceConfig;
+use ldk_node::probing::{ProbingConfig, ProbingConfigBuilder};
 use log::LevelFilter;
 use serde::{Deserialize, Serialize};
 
@@ -64,6 +66,7 @@ pub struct Config {
 	pub log_max_files: usize,
 	pub log_to_file: bool,
 	pub pathfinding_scores_source_url: Option<String>,
+	pub probing_config: Option<ProbingConfig>,
 	pub async_payments_role: Option<AsyncPaymentsRole>,
 	pub metrics_enabled: bool,
 	pub poll_metrics_interval: Option<u64>,
@@ -137,6 +140,7 @@ struct ConfigBuilder {
 	log_max_files: Option<usize>,
 	log_to_file: Option<bool>,
 	pathfinding_scores_source_url: Option<String>,
+	probing: Option<ProbingTomlConfig>,
 	async_payments_role: Option<String>,
 	metrics_enabled: Option<bool>,
 	poll_metrics_interval: Option<u64>,
@@ -214,6 +218,10 @@ impl ConfigBuilder {
 			self.metrics_password = metrics.password.or(self.metrics_password.clone());
 		}
 
+		if let Some(probing) = toml.probing {
+			self.probing = Some(probing);
+		}
+
 		if let Some(tor) = toml.tor {
 			self.tor_proxy_address = Some(tor.proxy_address)
 		}
@@ -274,6 +282,36 @@ impl ConfigBuilder {
 
 		if let Some(async_payments_role) = &args.node_async_payments_role {
 			self.async_payments_role = Some(async_payments_role.clone());
+		}
+
+		if args.has_probing_options() {
+			let probing = self.probing.get_or_insert_with(ProbingTomlConfig::default);
+			if let Some(probing_strategy) = &args.probing_strategy {
+				probing.strategy = Some(probing_strategy.clone());
+				match probing_strategy.trim().to_ascii_lowercase().as_str() {
+					"high_degree" | "high-degree" => probing.max_hops = None,
+					"random_walk" | "random-walk" => probing.top_node_count = None,
+					_ => {},
+				}
+			}
+			if let Some(top_node_count) = args.probing_top_node_count {
+				probing.top_node_count = Some(top_node_count);
+			}
+			if let Some(max_hops) = args.probing_max_hops {
+				probing.max_hops = Some(max_hops);
+			}
+			if let Some(interval_secs) = args.probing_interval_secs {
+				probing.interval_secs = Some(interval_secs);
+			}
+			if let Some(max_locked_msat) = args.probing_max_locked_msat {
+				probing.max_locked_msat = Some(max_locked_msat);
+			}
+			if let Some(diversity_penalty_msat) = args.probing_diversity_penalty_msat {
+				probing.diversity_penalty_msat = Some(diversity_penalty_msat);
+			}
+			if let Some(cooldown_secs) = args.probing_cooldown_secs {
+				probing.cooldown_secs = Some(cooldown_secs);
+			}
 		}
 
 		if args.metrics_enabled {
@@ -484,6 +522,8 @@ impl ConfigBuilder {
 
 		let pathfinding_scores_source_url = self.pathfinding_scores_source_url;
 
+		let probing_config = build_probing_config(self.probing)?;
+
 		let async_payments_role =
 			self.async_payments_role.as_deref().map(parse_async_payments_role).transpose()?;
 
@@ -544,6 +584,7 @@ impl ConfigBuilder {
 			log_max_files,
 			log_to_file,
 			pathfinding_scores_source_url,
+			probing_config,
 			async_payments_role,
 			metrics_enabled,
 			poll_metrics_interval,
@@ -568,6 +609,7 @@ pub struct TomlConfig {
 	log: Option<LogConfig>,
 	tls: Option<TomlTlsConfig>,
 	metrics: Option<MetricsTomlConfig>,
+	probing: Option<ProbingTomlConfig>,
 	tor: Option<TomlTorConfig>,
 	hrn: Option<HrnTomlConfig>,
 }
@@ -643,6 +685,18 @@ struct MetricsTomlConfig {
 	poll_metrics_interval: Option<u64>,
 	username: Option<String>,
 	password: Option<String>,
+}
+
+#[derive(Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+struct ProbingTomlConfig {
+	strategy: Option<String>,
+	top_node_count: Option<usize>,
+	max_hops: Option<usize>,
+	interval_secs: Option<u64>,
+	max_locked_msat: Option<u64>,
+	diversity_penalty_msat: Option<u64>,
+	cooldown_secs: Option<u64>,
 }
 
 #[derive(Deserialize, Serialize)]
@@ -755,6 +809,82 @@ fn parse_async_payments_role(role: &str) -> io::Result<AsyncPaymentsRole> {
 			),
 		)),
 	}
+}
+
+fn build_probing_config(config: Option<ProbingTomlConfig>) -> io::Result<Option<ProbingConfig>> {
+	let Some(config) = config else {
+		return Ok(None);
+	};
+	let ProbingTomlConfig {
+		strategy,
+		top_node_count,
+		max_hops,
+		interval_secs,
+		max_locked_msat,
+		diversity_penalty_msat,
+		cooldown_secs,
+	} = config;
+
+	let strategy = strategy.ok_or_else(|| missing_field_err("probing.strategy"))?;
+	let mut builder = match strategy.trim().to_ascii_lowercase().as_str() {
+		"high_degree" | "high-degree" => {
+			if max_hops.is_some() {
+				return Err(io::Error::new(
+					io::ErrorKind::InvalidInput,
+					"`probing.max_hops` only applies to the `random_walk` strategy",
+				));
+			}
+			let top_node_count =
+				top_node_count.ok_or_else(|| missing_field_err("probing.top_node_count"))?;
+			if top_node_count == 0 {
+				return Err(io::Error::new(
+					io::ErrorKind::InvalidInput,
+					"`probing.top_node_count` must be greater than 0",
+				));
+			}
+			ProbingConfigBuilder::high_degree(top_node_count)
+		},
+		"random_walk" | "random-walk" => {
+			if top_node_count.is_some() {
+				return Err(io::Error::new(
+					io::ErrorKind::InvalidInput,
+					"`probing.top_node_count` only applies to the `high_degree` strategy",
+				));
+			}
+			let max_hops = max_hops.ok_or_else(|| missing_field_err("probing.max_hops"))?;
+			if max_hops < 2 {
+				return Err(io::Error::new(
+					io::ErrorKind::InvalidInput,
+					"`probing.max_hops` must be at least 2",
+				));
+			}
+			ProbingConfigBuilder::random_walk(max_hops)
+		},
+		other => {
+			return Err(io::Error::new(
+				io::ErrorKind::InvalidInput,
+				format!(
+					"Invalid probing strategy '{}' configured; expected 'high_degree' or 'random_walk'",
+					other
+				),
+			))
+		},
+	};
+
+	if let Some(interval_secs) = interval_secs {
+		builder.interval(Duration::from_secs(interval_secs));
+	}
+	if let Some(max_locked_msat) = max_locked_msat {
+		builder.max_locked_msat(max_locked_msat);
+	}
+	if let Some(diversity_penalty_msat) = diversity_penalty_msat {
+		builder.diversity_penalty_msat(diversity_penalty_msat);
+	}
+	if let Some(cooldown_secs) = cooldown_secs {
+		builder.cooldown(Duration::from_secs(cooldown_secs));
+	}
+
+	Ok(Some(builder.build()))
 }
 
 #[derive(Deserialize, Serialize)]
@@ -973,6 +1103,55 @@ pub struct ArgsConfig {
 
 	#[arg(
 		long,
+		env = "LDK_SERVER_PROBING_STRATEGY",
+		help = "Enable background probing with `high_degree` or `random_walk`."
+	)]
+	probing_strategy: Option<String>,
+
+	#[arg(
+		long,
+		env = "LDK_SERVER_PROBING_TOP_NODE_COUNT",
+		help = "Number of highly connected nodes to cycle through with the `high_degree` probing strategy."
+	)]
+	probing_top_node_count: Option<usize>,
+
+	#[arg(
+		long,
+		env = "LDK_SERVER_PROBING_MAX_HOPS",
+		help = "Maximum path length for the `random_walk` probing strategy."
+	)]
+	probing_max_hops: Option<usize>,
+
+	#[arg(
+		long,
+		env = "LDK_SERVER_PROBING_INTERVAL_SECS",
+		help = "Interval between background probe attempts in seconds."
+	)]
+	probing_interval_secs: Option<u64>,
+
+	#[arg(
+		long,
+		env = "LDK_SERVER_PROBING_MAX_LOCKED_MSAT",
+		help = "Maximum total millisatoshis that background probes may lock in flight."
+	)]
+	probing_max_locked_msat: Option<u64>,
+
+	#[arg(
+		long,
+		env = "LDK_SERVER_PROBING_DIVERSITY_PENALTY_MSAT",
+		help = "Scoring penalty for recently probed channels. Useful with `high_degree`."
+	)]
+	probing_diversity_penalty_msat: Option<u64>,
+
+	#[arg(
+		long,
+		env = "LDK_SERVER_PROBING_COOLDOWN_SECS",
+		help = "Time before a node can be probed again. Applies to `high_degree`."
+	)]
+	probing_cooldown_secs: Option<u64>,
+
+	#[arg(
+		long,
 		env = "LDK_SERVER_METRICS_ENABLED",
 		help = "The option to enable the metrics endpoint. WARNING: This endpoint is unauthenticated."
 	)]
@@ -1006,6 +1185,18 @@ pub struct ArgsConfig {
 		help = "Tor daemon SOCKS proxy address. Only connections to OnionV3 peers will be made via this proxy; other connections (IPv4 peers, Electrum server) will not be routed over Tor."
 	)]
 	tor_proxy_address: Option<String>,
+}
+
+impl ArgsConfig {
+	fn has_probing_options(&self) -> bool {
+		self.probing_strategy.is_some()
+			|| self.probing_top_node_count.is_some()
+			|| self.probing_max_hops.is_some()
+			|| self.probing_interval_secs.is_some()
+			|| self.probing_max_locked_msat.is_some()
+			|| self.probing_diversity_penalty_msat.is_some()
+			|| self.probing_cooldown_secs.is_some()
+	}
 }
 
 pub fn load_config(args: &ArgsConfig) -> io::Result<Config> {
@@ -1148,6 +1339,13 @@ mod tests {
 			node_alias: Some(String::from("LDK Server CLI")),
 			pathfinding_scores_source_url: Some(String::from("https://example.com/")),
 			node_async_payments_role: Some(String::from("server")),
+			probing_strategy: None,
+			probing_top_node_count: None,
+			probing_max_hops: None,
+			probing_interval_secs: None,
+			probing_max_locked_msat: None,
+			probing_diversity_penalty_msat: None,
+			probing_cooldown_secs: None,
 			metrics_enabled: false,
 			poll_metrics_interval: None,
 			metrics_username: None,
@@ -1176,6 +1374,13 @@ mod tests {
 			storage_dir_path: None,
 			pathfinding_scores_source_url: None,
 			node_async_payments_role: None,
+			probing_strategy: None,
+			probing_top_node_count: None,
+			probing_max_hops: None,
+			probing_interval_secs: None,
+			probing_max_locked_msat: None,
+			probing_diversity_penalty_msat: None,
+			probing_cooldown_secs: None,
 			metrics_enabled: false,
 			poll_metrics_interval: None,
 			metrics_username: None,
@@ -1281,6 +1486,7 @@ mod tests {
 			log_max_files: 5,
 			log_to_file: true,
 			pathfinding_scores_source_url: None,
+			probing_config: None,
 			async_payments_role: Some(AsyncPaymentsRole::Client),
 			metrics_enabled: false,
 			poll_metrics_interval: None,
@@ -1682,6 +1888,7 @@ mod tests {
 			log_level: LevelFilter::Trace,
 			log_file_path: Some("/var/log/ldk-server.log".to_string()),
 			pathfinding_scores_source_url: Some("https://example.com/".to_string()),
+			probing_config: None,
 			async_payments_role: Some(AsyncPaymentsRole::Server),
 			metrics_enabled: false,
 			poll_metrics_interval: None,
@@ -1801,6 +2008,7 @@ mod tests {
 			log_level: LevelFilter::Trace,
 			log_file_path: Some("/var/log/ldk-server.log".to_string()),
 			pathfinding_scores_source_url: Some("https://example.com/".to_string()),
+			probing_config: None,
 			async_payments_role: Some(AsyncPaymentsRole::Server),
 			metrics_enabled: false,
 			poll_metrics_interval: None,
@@ -2085,6 +2293,179 @@ mod tests {
 			SocketAddress::from_str("[2001:db8::1]:53").unwrap()
 		);
 		assert!(parse_dns_server_address("invalid@address").is_err());
+	}
+
+	#[test]
+	fn test_probing_config_from_file() {
+		let storage_path = std::env::temp_dir();
+		let config_file_name = "test_probing_config.toml";
+		let mut args_config = empty_args_config();
+		args_config.config_file =
+			Some(storage_path.join(config_file_name).to_string_lossy().to_string());
+
+		let high_degree_config = format!(
+			r#"
+			[node]
+			network = "regtest"
+
+			[bitcoind]
+			rpc_address = "127.0.0.1:8332"
+			rpc_user = "user"
+			rpc_password = "password"
+
+			[probing]
+			strategy = "high_degree"
+			top_node_count = 100
+			interval_secs = 30
+			max_locked_msat = 500000
+			diversity_penalty_msat = 250
+			cooldown_secs = 1800
+			{}"#,
+			lsps2_service_config_for_feature()
+		);
+		fs::write(storage_path.join(config_file_name), high_degree_config).unwrap();
+		assert!(load_config(&args_config).unwrap().probing_config.is_some());
+
+		let random_walk_config = format!(
+			r#"
+			[node]
+			network = "regtest"
+
+			[bitcoind]
+			rpc_address = "127.0.0.1:8332"
+			rpc_user = "user"
+			rpc_password = "password"
+
+			[probing]
+			strategy = "random_walk"
+			max_hops = 5
+			{}"#,
+			lsps2_service_config_for_feature()
+		);
+		fs::write(storage_path.join(config_file_name), random_walk_config).unwrap();
+		assert!(load_config(&args_config).unwrap().probing_config.is_some());
+	}
+
+	#[test]
+	fn test_probing_config_validation() {
+		let high_degree = ProbingTomlConfig {
+			strategy: Some("high_degree".to_string()),
+			top_node_count: Some(100),
+			interval_secs: Some(30),
+			max_locked_msat: Some(500_000),
+			diversity_penalty_msat: Some(250),
+			cooldown_secs: Some(1800),
+			..ProbingTomlConfig::default()
+		};
+		assert!(build_probing_config(Some(high_degree)).unwrap().is_some());
+
+		let random_walk = ProbingTomlConfig {
+			strategy: Some("random_walk".to_string()),
+			max_hops: Some(5),
+			..ProbingTomlConfig::default()
+		};
+		assert!(build_probing_config(Some(random_walk)).unwrap().is_some());
+
+		let missing_strategy = build_probing_config(Some(ProbingTomlConfig {
+			top_node_count: Some(100),
+			..ProbingTomlConfig::default()
+		}))
+		.unwrap_err();
+		assert!(missing_strategy.to_string().contains("probing.strategy"));
+
+		let missing_strategy_option = build_probing_config(Some(ProbingTomlConfig {
+			strategy: Some("high_degree".to_string()),
+			..ProbingTomlConfig::default()
+		}))
+		.unwrap_err();
+		assert!(missing_strategy_option.to_string().contains("probing.top_node_count"));
+
+		let mismatched_option = build_probing_config(Some(ProbingTomlConfig {
+			strategy: Some("random_walk".to_string()),
+			top_node_count: Some(100),
+			max_hops: Some(5),
+			..ProbingTomlConfig::default()
+		}))
+		.unwrap_err();
+		assert!(mismatched_option.to_string().contains("probing.top_node_count"));
+
+		let invalid_strategy = build_probing_config(Some(ProbingTomlConfig {
+			strategy: Some("invalid".to_string()),
+			..ProbingTomlConfig::default()
+		}))
+		.unwrap_err();
+		assert!(invalid_strategy.to_string().contains("Invalid probing strategy"));
+
+		for max_hops in [0, 1] {
+			let invalid_max_hops = build_probing_config(Some(ProbingTomlConfig {
+				strategy: Some("random_walk".to_string()),
+				max_hops: Some(max_hops),
+				..ProbingTomlConfig::default()
+			}))
+			.unwrap_err();
+			assert!(invalid_max_hops.to_string().contains("`probing.max_hops` must be at least 2"));
+		}
+
+		let clamped_max_hops = ProbingTomlConfig {
+			strategy: Some("random_walk".to_string()),
+			max_hops: Some(20),
+			..ProbingTomlConfig::default()
+		};
+		assert!(build_probing_config(Some(clamped_max_hops)).unwrap().is_some());
+	}
+
+	#[test]
+	fn test_accepts_probing_args() {
+		let args_config = ArgsConfig::try_parse_from([
+			"ldk-server",
+			"--probing-strategy",
+			"high_degree",
+			"--probing-top-node-count",
+			"100",
+			"--probing-interval-secs",
+			"30",
+			"--probing-max-locked-msat",
+			"500000",
+			"--probing-diversity-penalty-msat",
+			"250",
+			"--probing-cooldown-secs",
+			"1800",
+		])
+		.unwrap();
+
+		assert_eq!(args_config.probing_strategy.as_deref(), Some("high_degree"));
+		assert_eq!(args_config.probing_top_node_count, Some(100));
+		assert_eq!(args_config.probing_interval_secs, Some(30));
+		assert_eq!(args_config.probing_max_locked_msat, Some(500_000));
+		assert_eq!(args_config.probing_diversity_penalty_msat, Some(250));
+		assert_eq!(args_config.probing_cooldown_secs, Some(1800));
+	}
+
+	#[test]
+	fn test_probing_args_override_strategy_specific_file_options() {
+		let mut builder = ConfigBuilder {
+			probing: Some(ProbingTomlConfig {
+				strategy: Some("high_degree".to_string()),
+				top_node_count: Some(100),
+				..ProbingTomlConfig::default()
+			}),
+			..ConfigBuilder::default()
+		};
+		let args_config = ArgsConfig::try_parse_from([
+			"ldk-server",
+			"--probing-strategy",
+			"random_walk",
+			"--probing-max-hops",
+			"5",
+		])
+		.unwrap();
+
+		builder.merge_args(&args_config);
+
+		let probing = builder.probing.unwrap();
+		assert_eq!(probing.strategy.as_deref(), Some("random_walk"));
+		assert_eq!(probing.top_node_count, None);
+		assert_eq!(probing.max_hops, Some(5));
 	}
 
 	#[test]


### PR DESCRIPTION
Allow operators to enable either built-in probing strategy through the config file, CLI arguments, or environment variables. Validate strategy settings and document the risk of probes locking outbound liquidity.