### PR TITLE
Default to the LDK scoring server

### DIFF
--- a/contrib/ldk-server-config.toml
+++ b/contrib/ldk-server-config.toml
@@ -5,7 +5,7 @@ listening_addresses = ["localhost:9735"]      # Lightning node listening address
 #announcement_addresses = ["54.3.7.81:9735"]  # Lightning node announcement addresses
 #grpc_service_address = "127.0.0.1:3536"      # LDK Server gRPC address (optional, defaults to 127.0.0.1:3536)
 alias = "ldk_server"                          # Lightning node alias
-#pathfinding_scores_source_url = ""           # External Pathfinding Scores Source
+#pathfinding_scores_source_url = "https://rapidsync.lightningdevkit.org/scoring/scorer.bin"  # External pathfinding scores source (optional, defaults to this URL on mainnet)
 #rgs_server_url = "https://rapidsync.lightningdevkit.org/snapshot/v2/"  # Optional: RGS URL for rapid gossip sync
 #async_payments_role = "client"               # Optional async payments role: "client" or "server"
 

--- a/contrib/ldk-server-config.toml
+++ b/contrib/ldk-server-config.toml
@@ -5,7 +5,7 @@ listening_addresses = ["localhost:9735"]      # Lightning node listening address
 #announcement_addresses = ["54.3.7.81:9735"]  # Lightning node announcement addresses
 #grpc_service_address = "127.0.0.1:3536"      # LDK Server gRPC address (optional, defaults to 127.0.0.1:3536)
 alias = "ldk_server"                          # Lightning node alias
-#pathfinding_scores_source_url = "https://rapidsync.lightningdevkit.org/scoring/scorer.bin"  # External pathfinding scores source (optional, defaults to this URL on mainnet)
+#pathfinding_scores_source_url = "https://rapidsync.lightningdevkit.org/scoring/scorer.bin"  # External pathfinding scores source (optional, defaults to this URL on mainnet; set to "" to disable)
 #rgs_server_url = "https://rapidsync.lightningdevkit.org/snapshot/v2/"  # Optional: RGS URL for rapid gossip sync
 #async_payments_role = "client"               # Optional async payments role: "client" or "server"
 

--- a/ldk-server/src/util/config.rs
+++ b/ldk-server/src/util/config.rs
@@ -23,6 +23,8 @@ use log::LevelFilter;
 use serde::{Deserialize, Serialize};
 
 const DEFAULT_GRPC_SERVICE_ADDRESS: &str = "127.0.0.1:3536";
+const DEFAULT_PATHFINDING_SCORES_SOURCE_URL: &str =
+	"https://rapidsync.lightningdevkit.org/scoring/scorer.bin";
 const DEFAULT_LOG_MAX_SIZE_MB: u64 = 50;
 const DEFAULT_LOG_ROTATION_INTERVAL_HOURS: u64 = 24;
 const DEFAULT_LOG_MAX_FILES: usize = 5;
@@ -482,7 +484,13 @@ impl ConfigBuilder {
 		#[cfg(not(feature = "experimental-lsps2-support"))]
 		let lsps2_service_config = None;
 
-		let pathfinding_scores_source_url = self.pathfinding_scores_source_url;
+		let pathfinding_scores_source_url = match self.pathfinding_scores_source_url {
+			Some(url) => Some(url),
+			None if network == Network::Bitcoin => {
+				Some(DEFAULT_PATHFINDING_SCORES_SOURCE_URL.to_string())
+			},
+			None => None,
+		};
 
 		let async_payments_role =
 			self.async_payments_role.as_deref().map(parse_async_payments_role).transpose()?;
@@ -960,7 +968,7 @@ pub struct ArgsConfig {
 	#[arg(
 		long,
 		env = "LDK_SERVER_PATHFINDING_SCORES_SOURCE_URL",
-		help = "The external scores source that is merged into the local scoring system to improve routing."
+		help = "The external scores source that is merged into the local scoring system to improve routing. Defaults to https://rapidsync.lightningdevkit.org/scoring/scorer.bin on mainnet."
 	)]
 	pathfinding_scores_source_url: Option<String>,
 
@@ -1517,6 +1525,26 @@ mod tests {
 
 		fs::write(storage_path.join(config_file_name), toml_config).unwrap();
 		assert!(load_config(&args_config).is_ok());
+	}
+
+	#[test]
+	fn test_mainnet_defaults_pathfinding_scores_source_url() {
+		let storage_path = std::env::temp_dir();
+		let config_file_name = "test_mainnet_pathfinding_scores_source_url.toml";
+
+		fs::write(storage_path.join(config_file_name), DEFAULT_CONFIG).unwrap();
+
+		let mut args_config = empty_args_config();
+		args_config.config_file =
+			Some(storage_path.join(config_file_name).to_string_lossy().to_string());
+		args_config.node_network = Some(Network::Bitcoin);
+
+		let config = load_config(&args_config).unwrap();
+
+		assert_eq!(
+			config.pathfinding_scores_source_url,
+			Some(DEFAULT_PATHFINDING_SCORES_SOURCE_URL.to_string())
+		);
 	}
 
 	#[test]

--- a/ldk-server/src/util/config.rs
+++ b/ldk-server/src/util/config.rs
@@ -485,6 +485,7 @@ impl ConfigBuilder {
 		let lsps2_service_config = None;
 
 		let pathfinding_scores_source_url = match self.pathfinding_scores_source_url {
+			Some(url) if url.is_empty() => None,
 			Some(url) => Some(url),
 			None if network == Network::Bitcoin => {
 				Some(DEFAULT_PATHFINDING_SCORES_SOURCE_URL.to_string())
@@ -968,7 +969,7 @@ pub struct ArgsConfig {
 	#[arg(
 		long,
 		env = "LDK_SERVER_PATHFINDING_SCORES_SOURCE_URL",
-		help = "The external scores source that is merged into the local scoring system to improve routing. Defaults to https://rapidsync.lightningdevkit.org/scoring/scorer.bin on mainnet."
+		help = "The external scores source that is merged into the local scoring system to improve routing. Defaults to https://rapidsync.lightningdevkit.org/scoring/scorer.bin on mainnet. Set to an empty string to disable."
 	)]
 	pathfinding_scores_source_url: Option<String>,
 
@@ -1545,6 +1546,26 @@ mod tests {
 			config.pathfinding_scores_source_url,
 			Some(DEFAULT_PATHFINDING_SCORES_SOURCE_URL.to_string())
 		);
+	}
+
+	#[test]
+	fn test_empty_pathfinding_scores_source_url_disables_source() {
+		let storage_path = std::env::temp_dir();
+		let config_file_name = "test_empty_pathfinding_scores_source_url.toml";
+		let toml_config = DEFAULT_CONFIG.replace(
+			"alias = \"LDK Server\"",
+			"alias = \"LDK Server\"\npathfinding_scores_source_url = \"\"",
+		);
+		fs::write(storage_path.join(config_file_name), toml_config).unwrap();
+
+		let mut args_config = empty_args_config();
+		args_config.config_file =
+			Some(storage_path.join(config_file_name).to_string_lossy().to_string());
+		args_config.node_network = Some(Network::Bitcoin);
+
+		let config = load_config(&args_config).unwrap();
+
+		assert_eq!(config.pathfinding_scores_source_url, None);
 	}
 
 	#[test]


### PR DESCRIPTION
Default to the `https://rapidsync.lightningdevkit.org/scoring/scorer.bin` scorer url. Treat an explicitly empty pathfinding scores source as absent so users can opt out of the default scorer through config inputs.