### PR TITLE
Make mnemonic RNG selection explicit

### DIFF
--- a/e2e-tests/tests/e2e.rs
+++ b/e2e-tests/tests/e2e.rs
@@ -17,7 +17,9 @@ use e2e_tests::{
 	LdkServerHandle, TestBitcoind,
 };
 use hex_conservative::{DisplayHex, FromHex};
+use ldk_node::bip39::{rand::rngs::OsRng, Language, Mnemonic};
 use ldk_node::bitcoin::hashes::{sha256, Hash};
+use ldk_node::entropy::NodeEntropy;
 use ldk_node::lightning::ln::msgs::SocketAddress;
 use ldk_node::lightning::offers::offer::Offer;
 use ldk_node::lightning_invoice::Bolt11Invoice;
@@ -1244,8 +1246,9 @@ async fn test_forwarded_payment_event() {
 	let b_addr = SocketAddress::from_str(&format!("127.0.0.1:{}", server_b.p2p_port)).unwrap();
 	builder_c.add_liquidity_source(b_node_id, b_addr, None, true);
 
-	let mnemonic_c = ldk_node::entropy::generate_entropy_mnemonic(None);
-	let node_entropy_c = ldk_node::entropy::NodeEntropy::from_bip39_mnemonic(mnemonic_c, None);
+	let mut rng = OsRng;
+	let mnemonic_c = Mnemonic::generate_in_with(&mut rng, Language::English, 24).unwrap();
+	let node_entropy_c = NodeEntropy::from_bip39_mnemonic(mnemonic_c, None);
 	let node_c = builder_c.build(node_entropy_c).unwrap();
 
 	node_c.start().unwrap();

--- a/ldk-server/src/util/entropy.rs
+++ b/ldk-server/src/util/entropy.rs
@@ -12,12 +12,13 @@ use std::str::FromStr;
 use std::{fs, io};
 
 use ldk_node::bip39::Mnemonic;
-use ldk_node::entropy::{generate_entropy_mnemonic, NodeEntropy};
+use ldk_node::entropy::NodeEntropy;
 use log::info;
 
 use crate::util::write_new;
 
 const DEFAULT_MNEMONIC_FILE: &str = "keys_mnemonic";
+const DEFAULT_MNEMONIC_ENTROPY_BYTES: usize = 32;
 
 pub(crate) fn load_or_generate_node_entropy(storage_dir: &Path) -> io::Result<NodeEntropy> {
 	let mnemonic_path = storage_dir.join(DEFAULT_MNEMONIC_FILE);
@@ -34,7 +35,7 @@ pub(crate) fn load_or_generate_node_entropy(storage_dir: &Path) -> io::Result<No
 		if let Some(parent) = mnemonic_path.parent() {
 			fs::create_dir_all(parent)?;
 		}
-		let mnemonic = generate_entropy_mnemonic(None);
+		let mnemonic = generate_entropy_mnemonic()?;
 		write_new(&mnemonic_path, format!("{}\n", mnemonic).as_bytes(), 0o600)?;
 		info!(
 			"Generated new BIP39 mnemonic at {}. Back up this file securely — it is required to recover on-chain funds.",
@@ -44,6 +45,12 @@ pub(crate) fn load_or_generate_node_entropy(storage_dir: &Path) -> io::Result<No
 	};
 
 	Ok(NodeEntropy::from_bip39_mnemonic(mnemonic, None))
+}
+
+fn generate_entropy_mnemonic() -> io::Result<Mnemonic> {
+	let mut entropy = [0u8; DEFAULT_MNEMONIC_ENTROPY_BYTES];
+	getrandom::getrandom(&mut entropy).map_err(io::Error::other)?;
+	Ok(Mnemonic::from_entropy(&entropy).expect("32-byte entropy must produce a valid mnemonic"))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Use direct OS randomness for the server's one-time mnemonic generation and an explicit OsRng in the E2E setup. A thread-local generator is not needed for these infrequent operations.